### PR TITLE
Implement stem and leaf tables

### DIFF
--- a/R/descriptives.R
+++ b/R/descriptives.R
@@ -189,7 +189,7 @@ Descriptives <- function(jaspResults, dataset, options) {
     if(is.null(jaspResults[["stemAndLeaf"]])) {
       jaspResults[["stemAndLeaf"]] <- createJaspContainer(gettext("Stem and Leaf"))
       jaspResults[["stemAndLeaf"]]$dependOn(c("splitby", "stemAndLeaf", "stemAndLeafScale"))
-      jaspResults[["scatterPlots"]]$position <- 11
+      jaspResults[["stemAndLeaf"]]$position <- 11
     }
 
     numericOrFactorVariables <- Filter(function(var) .descriptivesIsNumericColumn(dataset.factors, var), variables)

--- a/R/descriptives.R
+++ b/R/descriptives.R
@@ -1491,6 +1491,16 @@ Descriptives <- function(jaspResults, dataset, options) {
 
 .descriptivesStemAndLeafCreateSingleTable <- function(x, title, scale = 1, width = 80, atom = 1e-08) {
 
+  tb <- createJaspTable(title = title)
+  tb$addColumnInfo(name = "left",  title =  "Stem", type = "integer")
+  tb$addColumnInfo(name = "sep",   title =  "",     type = "separator")
+  tb$addColumnInfo(name = "right", title =  "Leaf", type = "string")
+
+  if (length(na.omit(x)) < 2L) {
+    tb$setError(gettext("A stem and leaf table could not be made because there are fewer than 2 non-missing observations"))
+    return(tb)
+  }
+
   # NOTE: graphics::stem is fast because it works in C, but it prints directly to the R output and returns NULL...
   # so we resort to capturing the string and manipulating it.
   # as.numeric ensures factors are handled correctly
@@ -1507,26 +1517,21 @@ Descriptives <- function(jaspResults, dataset, options) {
     digits <- as.numeric(regmatches(originalFootnote, gregexpr("[[:digit:]]+", originalFootnote))[[1L]])
 
     footnote <- if (grepl("right", originalFootnote)) {
-      ngettext(digits,
+      sprintf(ngettext(digits,
         "The decimal point is %s digit to the right of the |",
         "The decimal point is %s digits to the right of the |"
-      )
+      ), digits)
     } else {
-      ngettext(digits,
+      sprintf(ngettext(digits,
         "The decimal point is %s digit to the left of the |",
         "The decimal point is %s digits to the left of the |"
-      )
+      ), digits)
     }
   }
 
   text  <- strsplit(other, " | ", fixed = TRUE)
   left  <- vapply(text, `[`, 1L, FUN.VALUE = character(1L))
   right <- vapply(text, function(x) if (length(x) == 1L) "" else x[2L], FUN.VALUE = character(1L))
-
-  tb <- createJaspTable(title = title)
-  tb$addColumnInfo(name = "left",  title =  "Stem", type = "integer")
-  tb$addColumnInfo(name = "sep",   title =  "",     type = "separator")
-  tb$addColumnInfo(name = "right", title =  "Leaf", type = "string")
 
   tb[["left"]]  <- left
   tb[["sep"]]   <- rep("|", length(left))

--- a/inst/qml/Descriptives.qml
+++ b/inst/qml/Descriptives.qml
@@ -19,6 +19,7 @@
 import QtQuick			2.8
 import JASP.Controls	1.0
 import JASP.Widgets		1.0
+import JASP				1.0
 
 // All Analysis forms must be built with the From QML item
 Form
@@ -32,6 +33,12 @@ Form
 	}
 
 	CheckBox { name: "frequencyTables"; label: qsTr("Frequency tables (nominal and ordinal variables)"); }
+	CheckBox
+	{
+		name	: "stemAndLeaf";
+		label	: qsTr("Stem and leaf tables")
+		DoubleField	{name: "stemAndLeafScale";	label: qsTr("scale");	negativeValues: false;	inclusive: JASP.MaxOnly;	max: 200;	defaultValue: 1.0; }
+	}
 
 	Section
 	{

--- a/inst/qml/Descriptives.qml
+++ b/inst/qml/Descriptives.qml
@@ -37,7 +37,12 @@ Form
 	{
 		name	: "stemAndLeaf";
 		label	: qsTr("Stem and leaf tables")
-		DoubleField	{name: "stemAndLeafScale";	label: qsTr("scale");	negativeValues: false;	inclusive: JASP.MaxOnly;	max: 200;	defaultValue: 1.0; }
+		DoubleField
+		{
+			name: "stemAndLeafScale";	label: qsTr("scale");	negativeValues: false;	inclusive: JASP.MaxOnly;	max: 200;	defaultValue: 1.0;
+			info: qsTr("The scale parameter controls how much the table is expanded. For example, scale = 2 will cause the table to be roughly twice as long as the default (scale = 1).")
+		}
+		info	: qsTr("Create a Stem and leaf table.")
 	}
 
 	Section

--- a/tests/testthat/test-descriptives.R
+++ b/tests/testthat/test-descriptives.R
@@ -142,7 +142,7 @@ test_that("Pie chart matches", {
   options$descriptivesPiechart <- TRUE
   options$colorPalette <- "ggplot2"
   results <- jaspTools::runAnalysis("Descriptives", "test.csv", options)
-  
+
   testPlot <- results[["state"]][["figures"]][[1]][["obj"]]
   jaspTools::expect_equal_plots(testPlot, "pieChart", dir="Descriptives")
 })
@@ -155,9 +155,9 @@ test_that("Analysis handles identical variables", {
   options$shapiro <- TRUE
   options$skewness <- TRUE
   options$kurtosis <- TRUE
-  
+
   results <- jaspTools::runAnalysis("Descriptives", "test.csv", options)
-  
+
   jaspTools::expect_equal_tables(results[['results']][['stats']][['data']],
                       list(-1.19915675837133, 1, 1.007309698, -0.33853731055, -1.625143884,
                            0, 0.0819021844894419, 0.915696014062066, 0.338805595442952,
@@ -184,7 +184,7 @@ test_that("Analysis handles identical variables", {
                            0.512103336707757, 20, "debSame", 0, 0, 0, 0, "NaN", 5, 12.3,
                            12.3, 12.3, 0, "NaN", "NaN", "NaN", 0, 0.992383612541845, 0.512103336707757,
                            20, "debSame"))
-  
+
   # also check footnotes
   jaspTools::expect_equal_tables(results[['results']][['stats']][['footnotes']],
                       list("Kurtosis", "P-value of Shapiro-Wilk", "Shapiro-Wilk", "Skewness",
@@ -195,11 +195,49 @@ test_that("Analysis explains supremum and infimum of empty sets", {
   options <- analysisOptions("Descriptives")
   options$variables <- "debMiss99"
   options$splitby <- "contBinom"
-  
+
   results <- jaspTools::runAnalysis("Descriptives", "test.csv", options)
-  
+
   jaspTools::expect_equal_tables(results[['results']][['stats']][['footnotes']],
-                      list("Maximum", "Minimum", 22, "debMiss991", 0, 
+                      list("Maximum", "Minimum", 22, "debMiss991", 0,
                            "Infimum (minimum) of an empty set is <unicode>, supremum (maximum) of an empty set is -<unicode>.")
                       )
+})
+
+test_that("Stem and leaf tables match", {
+
+  options <- jaspTools::analysisOptions("Descriptives")
+  options$variables <- "contNormal"
+  options$stemAndLeaf <- TRUE
+  options$stemAndLeafScale <- 1.2
+  results <- jaspTools::runAnalysis("Descriptives", "test.csv", options)
+  table <- results[["results"]][["stemAndLeaf"]][["collection"]][["stemAndLeaf_stem_and_leaf_contNormal"]][["data"]]
+  expect_equal_tables(
+    table,
+    list(-3, 0, "|", -2, 320, "|", -1, 66644444431000, "|", 0, 9.99988888877778e+41,
+         "|", 0, 1.12223333334445e+27, "|", 1, 1469, "|", 2, 27, "|",
+         3, 4, "|"),
+    label = "stem and life without split"
+  )
+
+  options$splitby <- "contBinom"
+  results <- jaspTools::runAnalysis("Descriptives", "test.csv", options)
+  table0 <- results[["results"]][["stemAndLeaf"]][["collection"]][["stemAndLeaf_contNormal"]][["collection"]][["stemAndLeaf_contNormal_stem_and_leaf_contNormal_0"]][["data"]]
+  expect_equal_tables(
+    table0,
+    list(-2, 320, "|", -1, 6, "|", -1, 44430, "|", 0, 99988887777766672,
+         "|", 0, 4441, "|", 0, 11222333333444, "|", 0, 555668, "|", 1,
+         1, "|", 1, 6, "|", 2, "", "|", 2, 7, "|", 3, 4, "|"),
+    label = "stem and life with split - 0"
+  )
+
+  table1 <- results[["results"]][["stemAndLeaf"]][["collection"]][["stemAndLeaf_contNormal"]][["collection"]][["stemAndLeaf_contNormal_stem_and_leaf_contNormal_1"]][["data"]]
+  expect_equal_tables(
+    table1,
+    list(-3, 0, "|", -2, "", "|", -2, "", "|", -1, 66, "|", -1, 444100,
+         "|", 0, 988777665, "|", 0, 444443221111, "|", 0, 4, "|", 0,
+         5556689, "|", 1, 4, "|", 1, 9, "|", 2, 2, "|"),
+    label = "stem and life with split - 1"
+  )
+
 })


### PR DESCRIPTION
Fixes one part of jasp-stats/jasp-issues#684 and implements stem and leaf tables. Dot plots will be implemented in another PR.

Sequel of https://github.com/jasp-stats/jasp-desktop/pull/4273/files

Example:

![image](https://user-images.githubusercontent.com/21319932/92482611-18436c80-f1e8-11ea-80a5-47641c0bfe25.png)