### PR TITLE
new option: maximum distinct values for frequency tables

### DIFF
--- a/inst/qml/Descriptives.qml
+++ b/inst/qml/Descriptives.qml
@@ -32,7 +32,20 @@ Form
 		AssignedVariablesList	{ name: "splitby";			title: qsTr("Split");		singleVariable: true; suggestedColumns: ["ordinal", "nominal"];	id: splitBy }
 	}
 
-	CheckBox { name: "frequencyTables"; label: qsTr("Frequency tables (nominal and ordinal variables)"); }
+	CheckBox
+	{
+		name:			"frequencyTables"
+		label:			qsTr("Frequency tables")
+		IntegerField
+		{
+			name:			"frequencyTablesMaximumAmount"
+			label:			qsTr("Maximum distinct values")
+			min:			1
+			defaultValue:	10
+			fieldWidth:		50
+			max:			2e2
+		}
+	}
 	CheckBox
 	{
 		name	: "stemAndLeaf";


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/647

If someone really wants to they can get frequency tables variables with many distinct values:

![image](https://user-images.githubusercontent.com/21319932/100994334-c4ca8b80-3556-11eb-808e-cc8c89a73d61.png)

If all variables exceed the maximum number of distinct values a dummy table with footnote is shown:

![image](https://user-images.githubusercontent.com/21319932/100994554-fe9b9200-3556-11eb-8b34-6a1b83152bc7.png)

If some but not all variables exceed the maximum number of distinct values a footnote is shown in the first table:

![image](https://user-images.githubusercontent.com/21319932/100994726-2f7bc700-3557-11eb-8bdf-a588a93f8f00.png)
