### PR TITLE
Added a checkbox to transpose the main table

### DIFF
--- a/R/descriptives.R
+++ b/R/descriptives.R
@@ -267,7 +267,7 @@ Descriptives <- function(jaspResults, dataset, options) {
   equalGroupsNo           <- options$percentileValuesEqualGroupsNo
   percentilesPercentiles  <- unique(options$percentileValuesPercentilesPercentiles)
   stats                   <- createJaspTable(gettext("Descriptive Statistics"))
-  stats$transpose         <- TRUE
+  stats$transpose         <- !options[["transposeMainTable"]] # the table is transposed by default
   stats$position          <- 1
   
   if (numberMissingSplitBy) 
@@ -275,7 +275,8 @@ Descriptives <- function(jaspResults, dataset, options) {
   
 
   stats$dependOn(c("splitby", "variables", "percentileValuesEqualGroupsNo", "percentileValuesPercentilesPercentiles", "mean", "standardErrorMean",
-    "median", "mode", "standardDeviation", "cOfVariation", "variance", "skewness", "kurtosis", "shapiro", "range", "iqr", "mad","madrobust", "minimum", "maximum", "sum", "percentileValuesQuartiles", "percentileValuesEqualGroups", "percentileValuesPercentiles"))
+    "median", "mode", "standardDeviation", "cOfVariation", "variance", "skewness", "kurtosis", "shapiro", "range", "iqr", "mad","madrobust", "minimum", "maximum",
+    "sum", "percentileValuesQuartiles", "percentileValuesEqualGroups", "percentileValuesPercentiles", "transposeMainTable"))
 
   if (wantsSplit) {
     stats$transposeWithOvertitle <- TRUE

--- a/inst/qml/Descriptives.qml
+++ b/inst/qml/Descriptives.qml
@@ -34,6 +34,13 @@ Form
 
 	CheckBox
 	{
+		name	: "transposeMainTable"
+		label	: qsTr("Transpose descriptives table")
+		checked	: false
+	}
+
+	CheckBox
+	{
 		name:			"frequencyTables"
 		label:			qsTr("Frequency tables")
 		IntegerField


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/1219

adds a checkbox 

![image](https://user-images.githubusercontent.com/21319932/111973882-3bd46180-8aff-11eb-9d48-c9f7deeb7c1f.png)

so that you can get the table also in a much more space-efficient long-format. Top is old, bottom is new:

![image](https://user-images.githubusercontent.com/21319932/111973993-59a1c680-8aff-11eb-9fec-1c92069366ee.png)

I'm not sure why the footnotes are different, I think something goes wrong with jaspResults there.

