### PR TITLE
restore the "natural order" without renaming percentiles to positions & this time without conflicts

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: jaspDescriptives
 Type: Package
 Title: Descriptives Module for JASP
 Version: 0.15.0
-Date: 2019-08-29
+Date: 2021-05-30
 Author: JASP Team
 Website: jasp-stats.org
 Maintainer: JASP Team <info@jasp-stats.org>

--- a/inst/Description.qml
+++ b/inst/Description.qml
@@ -6,7 +6,7 @@ Description
 	name		: "jaspDescriptives"
 	title		: qsTr("Descriptives")
 	description	: qsTr("Explore the data with tables and plots")
-	version		: "0.13"
+	version		: "0.15"
 	author		: "JASP Team"
 	maintainer	: "JASP Team <jasp-stats.org>"
 	website		: "jasp-stats.org"

--- a/inst/help/descriptives.md
+++ b/inst/help/descriptives.md
@@ -21,15 +21,14 @@ Descriptives allows the user to obtain basic descriptive statistics, histograms 
     - Has selectable boxplot, violin, and jitter elements for displaying the distribution of the data.
 
 ### Statistics
+- Central Tendency (only for continuous variables):
+  - Mode: Mode of the data points; if more than one mode exists, only the first is reported.
+  - Median: Median of the data points.
+  - Mean: Arithmetic mean of the data points
 - Percentile Values:
   - Quartiles: Displays the 25th, 50th, and 75th percentiles of the data points.
   - Cut points for x equal groups: Displays the cut points that divide the data into x equal groups; default is 4 equal groups.
   - Percentiles: Displays the xth percentile; percentile values must be separated by comma.
-- Central Tendency (only for continuous variables):
-  - Mean: Arithmetic mean of the data points
-  - Median: Median of the data points.
-  - Mode: Mode of the data points; if more than one mode exists, only the first is reported.
-  - Sum: Sum of the data points.
 - Dispersion (only for continuous variables):
   - S.E. Mean: Standard error of the mean.
   - Std. deviation: Standard deviation of the data points.
@@ -45,16 +44,17 @@ Descriptives allows the user to obtain basic descriptive statistics, histograms 
   - Skewness: Skewness of the distribution of the data points.
   - Kurtosis: Kurtosis of the distribution of the data points.
   - Shapiro-Wilk test
+  - Sum: Sum of the data points.
 
 ### Output
 -------
 #### Descriptive Statistics
 - Valid: Number of valid cases.
 - Missing: Number of missing values.
+- Mode: Mode of the data points.
+- Median: Median of the data points.
 - Mean: Arithmetic mean of the data points.
 - Std. Error of Mean: Standard error of the mean.
-- Median: Median of the data points.
-- Mode: Mode of the data points.
 - Std. Deviation: Standard deviation of the data points.
 - MAD: Median absolute deviation
 - IQR: Interquartile range
@@ -68,10 +68,10 @@ Descriptives allows the user to obtain basic descriptive statistics, histograms 
 - Range: Range of the data points.
 - Minimum: Minimum value of the data points.
 - Maximum: Maximum value of the data points.
-- Sum: Sum of the data points.
 - Quartiles: 25th, 50th, and 75th percentiles of the data points.
 - Cut points for x equal groups: Cut points that divide the data into x equal groups.
 - Percentiles: Displays the xth percentiles.
+- Sum: Sum of the data points.
 
 #### Distribution Plots
 - For continuous variables, displays a histogram and the fit of a nonparametric density estimator.

--- a/inst/qml/Descriptives.qml
+++ b/inst/qml/Descriptives.qml
@@ -210,7 +210,16 @@ Form
 
 		Group
 		{
-			title:	qsTr("Percentile Values")
+			title: qsTr("Central Tendency")
+
+			CheckBox { name: "mode";			label: qsTr("Mode");					}
+			CheckBox { name: "median";			label: qsTr("Median")					}
+			CheckBox { name: "mean";			label: qsTr("Mean");	checked: true	}
+		}
+
+		Group
+		{
+			title:	qsTr("Positions")
 
 			CheckBox { name: "percentileValuesQuartiles";	label: qsTr("Quartiles") }
 			CheckBox
@@ -243,15 +252,6 @@ Form
 			}
 		}
 
-		Group
-		{
-			title: qsTr("Central Tendency")
-
-			CheckBox { name: "mean";			label: qsTr("Mean");	checked: true	}
-			CheckBox { name: "median";			label: qsTr("Median")					}
-			CheckBox { name: "mode";			label: qsTr("Mode");					}
-			CheckBox { name: "sum";				label: qsTr("Sum");						}
-		}
 
 		Group
 		{
@@ -277,6 +277,7 @@ Form
 			CheckBox { name: "skewness";			label: qsTr("Skewness")						}
 			CheckBox { name: "kurtosis";			label: qsTr("Kurtosis")						}
 			CheckBox { name: "shapiro";				label: qsTr("Shapiro-Wilk test")			}
+			CheckBox { name: "sum";					label: qsTr("Sum");							}
 		}
 
 		CheckBox { name: "statisticsValuesAreGroupMidpoints"; label: qsTr("Values are group midpoints"); debug: true }

--- a/inst/qml/Descriptives.qml
+++ b/inst/qml/Descriptives.qml
@@ -219,7 +219,7 @@ Form
 
 		Group
 		{
-			title:	qsTr("Positions")
+			title:	qsTr("Quantiles")
 
 			CheckBox { name: "percentileValuesQuartiles";	label: qsTr("Quartiles") }
 			CheckBox


### PR DESCRIPTION
Apparently I cannot change a name of a function  like "percentileValues" without breaking everything, so I reverted that and also gave the conflicts another try.

The really new changes I made are:
~~a) Changed section and variable name percentileValues to postions (as this better reflects the content of the section. Is this ok, or do other modules depend on the exact variable name?~~
b) Every textbook I know begins with mode median mean in this order. JASP reflects this now also in the output table.
c) Sum is a better fit for section distribution

If this commit is accepted I will reorder further items in this module to make it more beginner friendly.