### PR TITLE
Make it possible to hide valid and missing

### DIFF
--- a/R/descriptives.R
+++ b/R/descriptives.R
@@ -275,7 +275,7 @@ Descriptives <- function(jaspResults, dataset, options) {
 
   stats$dependOn(c("splitby", "variables", "percentileValuesEqualGroupsNo", "percentileValuesPercentilesPercentiles", "mode", "median", "mean", "standardErrorMean",
     "standardDeviation", "cOfVariation", "variance", "skewness", "kurtosis", "shapiro", "range", "iqr", "mad", "madrobust", "minimum", "maximum",
-    "sum", "percentileValuesQuartiles", "percentileValuesEqualGroups", "percentileValuesPercentiles", "transposeMainTable"))
+    "sum", "percentileValuesQuartiles", "percentileValuesEqualGroups", "percentileValuesPercentiles", "transposeMainTable", "valid", "missing"))
 
   if (wantsSplit) {
     stats$transposeWithOvertitle <- TRUE
@@ -285,9 +285,8 @@ Descriptives <- function(jaspResults, dataset, options) {
     stats$addColumnInfo(name="Variable",  title="", type="string")
   }
 
-  stats$addColumnInfo(name="Valid",   title=gettext("Valid"), type="integer")
-  stats$addColumnInfo(name="Missing", title=gettext("Missing"), type="integer")
-
+  if (options$valid)                stats$addColumnInfo(name="Valid",                       title=gettext("Valid"),                   type="integer")
+  if (options$missing)              stats$addColumnInfo(name="Missing",                     title=gettext("Missing"),                 type="integer")
   if (options$mode)                 stats$addColumnInfo(name="Mode",                        title=gettext("Mode"),                    type="number")
   if (options$median)               stats$addColumnInfo(name="Median",                      title=gettext("Median"),                  type="number")
   if (options$mean)                 stats$addColumnInfo(name="Mean",                        title=gettext("Mean"), 				            type="number")
@@ -403,14 +402,14 @@ Descriptives <- function(jaspResults, dataset, options) {
   rows        <- length(column)
   na.omitted  <- na.omit(column)
 
-  resultsCol[["Valid"]]   <- length(na.omitted)
-  resultsCol[["Missing"]] <- rows - length(na.omitted)
-
   if (base::is.factor(na.omitted) && (options$mode || options$median || options$mean || options$minimum || options$standardErrorMean || options$iqr || options$mad || options$madrobust || options$kurtosis || options$shapiro || options$skewness || options$percentileValuesQuartiles || options$variance || options$standardDeviation ||  options$cOfVariation || options$percentileValuesPercentiles || options$sum || options$maximum)) {
     shouldAddNominalTextFootnote <- TRUE
   }
 
   shouldAddIdenticalFootnote <- all(na.omitted[1] == na.omitted) && (options$skewness || options$kurtosis || options$shapiro)
+
+  resultsCol[["Valid"]]                   <- if (options$valid)   length(na.omitted)
+  resultsCol[["Missing"]]                 <- if (options$missing) rows - length(na.omitted)
 
   resultsCol[["Median"]]                  <- .descriptivesDescriptivesTable_subFunction_OptionChecker(options$median,            na.omitted, median)
   resultsCol[["Mean"]]                    <- .descriptivesDescriptivesTable_subFunction_OptionChecker(options$mean,              na.omitted, mean)

--- a/R/descriptives.R
+++ b/R/descriptives.R
@@ -408,7 +408,8 @@ Descriptives <- function(jaspResults, dataset, options) {
 
   shouldAddIdenticalFootnote <- all(na.omitted[1] == na.omitted) && (options$skewness || options$kurtosis || options$shapiro)
 
-  resultsCol[["Valid"]]                   <- if (options$valid)   length(na.omitted)
+  valid <- length(na.omitted)
+  resultsCol[["Valid"]]                   <- if (options$valid)   valid
   resultsCol[["Missing"]]                 <- if (options$missing) rows - length(na.omitted)
 
   resultsCol[["Median"]]                  <- .descriptivesDescriptivesTable_subFunction_OptionChecker(options$median,            na.omitted, median)
@@ -432,7 +433,7 @@ Descriptives <- function(jaspResults, dataset, options) {
   resultsCol[["Sum"]]                     <- .descriptivesDescriptivesTable_subFunction_OptionChecker(options$sum,               na.omitted, sum)
 
   # should explain supremum and infimum of an empty set?
-  if((options$minimum || options$maximum) && resultsCol[['Valid']] == 0) shouldAddExplainEmptySet <- TRUE else shouldAddExplainEmptySet <- FALSE
+  if((options$minimum || options$maximum) && valid == 0) shouldAddExplainEmptySet <- TRUE else shouldAddExplainEmptySet <- FALSE
 
   if (options$mode) {
     if (base::is.factor(na.omitted) == FALSE) {

--- a/inst/qml/Descriptives.qml
+++ b/inst/qml/Descriptives.qml
@@ -210,6 +210,13 @@ Form
 
 		Group
 		{
+			title: qsTr("Sample Size")
+			CheckBox { name: "valid";			label: qsTr("Valid");	checked: true	}
+			CheckBox { name: "missing";			label: qsTr("Missing");	checked: true	}
+		}
+
+		Group
+		{
 			title: qsTr("Central Tendency")
 
 			CheckBox { name: "mode";			label: qsTr("Mode");					}


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/1480

In this table
![image](https://user-images.githubusercontent.com/21319932/139426477-0a443b78-4949-475c-a3e5-0059aeb14c79.png)

the highlighted rows could not be removed. For all other rows, there is an option to remove it. This PR adds two checkboxes so you can also remove those two rows, as requested in the linked issue requested.
![image](https://user-images.githubusercontent.com/21319932/139426648-339de406-b6c9-433c-b63c-6185f8b8237f.png)
