### PR TITLE
Scale dotplot dotsize with counts

### DIFF
--- a/R/descriptives.R
+++ b/R/descriptives.R
@@ -1281,6 +1281,16 @@ Descriptives <- function(jaspResults, dataset, options) {
     tb <- as.data.frame(table(x))
     scaleX <- ggplot2::scale_x_discrete(limits = factor(tb[, 1L]))
 
+    # so the geom_dotplot is very weird and the dot sizes are independent of the y-axis.
+    # hence to avoid exceeding the y-axis, we need to make the dots smaller...
+    # see also the many issues on the ggplot repo about the dotplot...
+    # for example https://github.com/tidyverse/ggplot2/issues/2203
+    # this post provides alternatives we should consider for the current implementation
+    # https://stackoverflow.com/questions/53697235/ggplot-dotplot-what-is-the-proper-use-of-geom-dotplot
+    maxFreq <- max(tb[["Freq"]])
+    if (maxFreq >= 17L)
+      dotsize <- 17 / maxFreq
+
   } else {
 
     xBreaks <- jaspGraphs::getPrettyAxisBreaks(x)

--- a/tests/testthat/_snaps/descriptives/dot-plot-large-counts.svg
+++ b/tests/testthat/_snaps/descriptives/dot-plot-large-counts.svg
@@ -1,0 +1,415 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
+</g>
+<defs>
+  <clipPath id='cpOC41MHw3MjAuMDB8MjAuNzF8NTEwLjE0'>
+    <rect x='8.50' y='20.71' width='711.50' height='489.43' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpOC41MHw3MjAuMDB8MjAuNzF8NTEwLjE0)'>
+<rect x='8.50' y='20.71' width='711.50' height='489.43' style='stroke-width: 10.67; stroke: none;' />
+<circle cx='60.56' cy='485.74' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='60.56' cy='481.44' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='60.56' cy='477.14' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='60.56' cy='472.84' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='60.56' cy='468.53' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='60.56' cy='464.23' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='60.56' cy='459.93' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='60.56' cy='455.63' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='60.56' cy='451.32' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='60.56' cy='447.02' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='147.33' cy='485.74' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='147.33' cy='481.44' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='147.33' cy='477.14' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='147.33' cy='472.84' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='147.33' cy='468.53' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='147.33' cy='464.23' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='147.33' cy='459.93' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='147.33' cy='455.63' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='147.33' cy='451.32' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='147.33' cy='447.02' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='147.33' cy='442.72' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='147.33' cy='438.42' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='147.33' cy='434.11' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='147.33' cy='429.81' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='147.33' cy='425.51' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='147.33' cy='421.21' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='147.33' cy='416.91' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='147.33' cy='412.60' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='147.33' cy='408.30' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='147.33' cy='404.00' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='485.74' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='481.44' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='477.14' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='472.84' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='468.53' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='464.23' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='459.93' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='455.63' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='451.32' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='447.02' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='442.72' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='438.42' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='434.11' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='429.81' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='425.51' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='421.21' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='416.91' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='412.60' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='408.30' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='404.00' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='399.70' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='395.39' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='391.09' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='386.79' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='382.49' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='378.19' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='373.88' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='369.58' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='365.28' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='234.10' cy='360.98' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='485.74' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='481.44' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='477.14' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='472.84' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='468.53' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='464.23' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='459.93' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='455.63' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='451.32' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='447.02' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='442.72' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='438.42' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='434.11' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='429.81' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='425.51' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='421.21' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='416.91' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='412.60' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='408.30' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='404.00' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='399.70' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='395.39' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='391.09' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='386.79' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='382.49' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='378.19' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='373.88' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='369.58' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='365.28' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='360.98' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='356.67' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='352.37' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='348.07' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='343.77' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='339.47' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='335.16' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='330.86' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='326.56' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='322.26' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='320.87' cy='317.95' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='485.74' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='481.44' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='477.14' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='472.84' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='468.53' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='464.23' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='459.93' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='455.63' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='451.32' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='447.02' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='442.72' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='438.42' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='434.11' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='429.81' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='425.51' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='421.21' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='416.91' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='412.60' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='408.30' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='404.00' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='399.70' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='395.39' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='391.09' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='386.79' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='382.49' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='378.19' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='373.88' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='369.58' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='365.28' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='360.98' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='356.67' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='352.37' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='348.07' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='343.77' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='339.47' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='335.16' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='330.86' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='326.56' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='322.26' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='317.95' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='313.65' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='309.35' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='305.05' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='300.75' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='296.44' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='292.14' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='287.84' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='283.54' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='279.23' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='407.64' cy='274.93' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='485.74' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='481.44' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='477.14' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='472.84' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='468.53' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='464.23' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='459.93' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='455.63' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='451.32' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='447.02' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='442.72' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='438.42' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='434.11' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='429.81' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='425.51' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='421.21' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='416.91' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='412.60' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='408.30' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='404.00' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='399.70' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='395.39' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='391.09' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='386.79' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='382.49' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='378.19' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='373.88' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='369.58' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='365.28' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='360.98' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='356.67' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='352.37' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='348.07' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='343.77' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='339.47' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='335.16' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='330.86' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='326.56' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='322.26' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='317.95' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='313.65' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='309.35' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='305.05' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='300.75' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='296.44' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='292.14' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='287.84' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='283.54' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='279.23' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='274.93' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='270.63' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='266.33' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='262.03' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='257.72' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='253.42' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='249.12' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='244.82' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='240.51' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='236.21' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='494.40' cy='231.91' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='485.74' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='481.44' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='477.14' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='472.84' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='468.53' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='464.23' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='459.93' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='455.63' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='451.32' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='447.02' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='442.72' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='438.42' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='434.11' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='429.81' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='425.51' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='421.21' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='416.91' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='412.60' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='408.30' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='404.00' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='399.70' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='395.39' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='391.09' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='386.79' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='382.49' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='378.19' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='373.88' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='369.58' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='365.28' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='360.98' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='356.67' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='352.37' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='348.07' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='343.77' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='339.47' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='335.16' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='330.86' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='326.56' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='322.26' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='317.95' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='313.65' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='309.35' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='305.05' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='300.75' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='296.44' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='292.14' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='287.84' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='283.54' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='279.23' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='274.93' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='270.63' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='266.33' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='262.03' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='257.72' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='253.42' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='249.12' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='244.82' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='240.51' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='236.21' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='231.91' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='227.61' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='223.31' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='219.00' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='214.70' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='210.40' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='206.10' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='201.79' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='197.49' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='193.19' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='581.17' cy='188.89' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='485.74' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='481.44' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='477.14' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='472.84' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='468.53' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='464.23' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='459.93' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='455.63' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='451.32' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='447.02' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='442.72' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='438.42' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='434.11' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='429.81' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='425.51' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='421.21' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='416.91' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='412.60' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='408.30' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='404.00' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='399.70' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='395.39' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='391.09' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='386.79' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='382.49' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='378.19' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='373.88' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='369.58' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='365.28' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='360.98' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='356.67' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='352.37' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='348.07' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='343.77' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='339.47' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='335.16' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='330.86' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='326.56' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='322.26' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='317.95' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='313.65' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='309.35' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='305.05' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='300.75' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='296.44' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='292.14' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='287.84' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='283.54' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='279.23' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='274.93' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='270.63' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='266.33' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='262.03' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='257.72' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='253.42' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='249.12' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='244.82' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='240.51' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='236.21' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='231.91' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='227.61' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='223.31' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='219.00' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='214.70' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='210.40' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='206.10' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='201.79' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='197.49' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='193.19' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='188.89' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='184.59' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='180.28' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='175.98' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='171.68' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='167.38' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='163.07' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='158.77' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='154.47' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='150.17' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<circle cx='667.94' cy='145.86' r='2.15' style='stroke-width: 0.75; fill: #BEBEBE;' />
+<line x1='60.25' y1='510.14' x2='668.26' y2='510.14' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<rect x='8.50' y='20.71' width='711.50' height='489.43' style='stroke-width: 0.00; stroke: none;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='8.50,510.14 8.50,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<polyline points='8.50,510.14 720.00,510.14 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<polyline points='60.56,518.64 60.56,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='147.33,518.64 147.33,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='234.10,518.64 234.10,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='320.87,518.64 320.87,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='407.64,518.64 407.64,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='494.40,518.64 494.40,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='581.17,518.64 581.17,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='667.94,518.64 667.94,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<text x='60.56' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>a</text>
+<text x='147.33' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>b</text>
+<text x='234.10' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='8.51px' lengthAdjust='spacingAndGlyphs'>c</text>
+<text x='320.87' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>d</text>
+<text x='407.64' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>e</text>
+<text x='494.40' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='4.72px' lengthAdjust='spacingAndGlyphs'>f</text>
+<text x='581.17' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>g</text>
+<text x='667.94' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>h</text>
+<text x='364.25' y='567.49' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='139.88px' lengthAdjust='spacingAndGlyphs'>factorLargeCounts</text>
+<text x='364.25' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='167.31px' lengthAdjust='spacingAndGlyphs'>dot_plot_large_counts</text>
+</g>
+</svg>

--- a/tests/testthat/test-descriptives.R
+++ b/tests/testthat/test-descriptives.R
@@ -280,3 +280,16 @@ test_that("interval plot across groups matches", {
   testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
   jaspTools::expect_equal_plots(testPlot, "interval_plot_across_facFive_contExpon")
 })
+
+
+dat <- data.frame(factorLargeCounts = factor(rep(letters[1:8], seq(10, 80, 10))))
+options <- analysisOptions("Descriptives")
+options$variables <- "factorLargeCounts"
+options$descriptivesDotPlot <- TRUE
+results <- runAnalysis("Descriptives", dat, options)
+
+test_that("dot plot with large counts is legible", {
+  plotName <- results[["results"]][["DotPlots"]][["collection"]][["DotPlots_factorLargeCounts"]][["data"]]
+  testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
+  jaspTools::expect_equal_plots(testPlot, "dot_plot_large_counts")
+})


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/1635 and adds a unit test.

The screenshot in the issue nicely shows the problem, the dots are stacked and exceed the y-limits. Now, unfortunately, this is not solved by changing the y-axis limits because geom_dotplot is actually a very terrible geom (see https://github.com/tidyverse/ggplot2/issues/2203). If you change the y-axis limits the plot actually stays the same...

The unit test SVG nicely shows what *should* happen in these cases, namely rescaling the size of the dots.

We could also change the dotplot implementation entirely, but I opted for less severe changes and left my thoughts as a comment in the code.

