### PR TITLE
Add cov/cor matrices to descriptives

### DIFF
--- a/inst/help/Descriptives.md
+++ b/inst/help/Descriptives.md
@@ -64,6 +64,14 @@ Descriptives allows the user to obtain basic descriptive statistics, histograms 
   - Confidence interval for the std. deviation: a confidence interval for the standard deviation based on bootstrap samples.
   - Confidence interval for the variance: a confidence interval for the variance based on bootstrap samples.
   - Bootstrap samples: the number of bootstrap samples to be used.
+- Association matrix:
+  - Covariance: Covariance value.
+  - Correlation: Pearson's correlation coefficient.
+  - Use: How to deal with missing values? 
+    - Everything: use all observations, resulting in NA when there are missing values.
+    - Complete observations: missing values are handled by casewise deletion (i.e., only use rows of the data set that are complete).
+    - Pairwise complete observations: use all complete pairs of observations on those variables. This can result in covariance or correlation matrices which are not positive semi-definite.
+
 
 ### Output
 -------

--- a/inst/help/Descriptives_nl.md
+++ b/inst/help/Descriptives_nl.md
@@ -63,6 +63,13 @@ Met beschrijvende statistieken kunt u basis beschrijvende statistieken verkrijge
   - Betrouwbaarheidsinterval voor de standaarddeviatie: een betrouwbaarheidsinterval voor de standaarddeviatie gebaseerd op bootstrap samples.
   - Betrouwbaarheidsinterval voor de variantie: een betrouwbaarheidsinterval voor de variantie gebaseerd op bootstrap samples.
   - Bootstrap samples: het aantal bootstrap samples.
+- Associatie matrix:
+  - Covariantie: Covariantie waarde.
+  - Correlatie: Pearson's correlatie coefficient.
+  - Use: Hoe om te gaan met ontbrekende waarden? 
+    - Alles: gebruik alle observaties; dit kan leiden tot NA's als er data ontbreken.
+    - Complete observaties: enkel complete observaties (rijen) worden gebruikt.
+    - Paarsgewijze complete observaties: gebruik paarsgewijs complete observaties. Dit kan leiden tot matrices die niet positief semi-definiet zijn.
 
 
 ### Uitvoer

--- a/inst/qml/Descriptives.qml
+++ b/inst/qml/Descriptives.qml
@@ -127,7 +127,8 @@ Form
 			CheckBox { name: "maximum";						label: qsTr("Maximum");				checked: true	}
 		}
 
-				Group
+
+		Group
 		{
 			title:		qsTr("Inference")
 			
@@ -197,7 +198,29 @@ Form
 				}
 			}
 		}
+		Group
+		{
+			title:	qsTr("Association matrix")
 
+			CheckBox { name: "covariance";		label: qsTr("Covariance"); id:covariance}
+			CheckBox { name: "correlation";		label: qsTr("Correlation"); id:correlation}
+
+			DropDown 
+			{
+				name: "associationMatrixUse"
+				id : associationMatrixUse
+				label: qsTr("Use")
+				enabled:  covariance.checked || correlation.checked
+				indexDefaultValue: 0
+				values:
+				[
+					{label: qsTr("Everything"),							value: "everything"},
+					{label: qsTr("Complete observations"),				value: "complete.obs"},
+					{label: qsTr("Pairwise compelete observations"),	value: "pairwise.complete.obs"}
+				]
+			}
+		}
+		
 		CheckBox { name: "statisticsValuesAreGroupMidpoints"; label: qsTr("Values are group midpoints"); debug: true }
 	}
 

--- a/tests/testthat/test-descriptives.R
+++ b/tests/testthat/test-descriptives.R
@@ -103,6 +103,24 @@ test_that("Descriptive Statistics table results match", {
 
 })
 
+
+test_that("Association matrices match", {
+  options <- jaspTools::analysisOptions("Descriptives")
+  options$variables <- c("contNormal",  "contGamma", "debMiss1")
+  options$covariance <- TRUE
+  options$correlation <- TRUE
+  results <- jaspTools::runAnalysis("Descriptives", "test.csv", options)
+  table <- results[["results"]][["associationMatrix"]][["collection"]][["associationMatrix_Correlation"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+                                 list("contNormal", -0.0592003859505643, 1, "", "contGamma", 1, -0.0592003859505643,
+                                      "", "debMiss1", "", "", 1))
+  
+  table <- results[["results"]][["associationMatrix"]][["collection"]][["associationMatrix_Covariance"]][["data"]]
+  jaspTools::expect_equal_tables(table,
+                                 list("contNormal", -0.0960185736017089, 1.1202393681253, "", "contGamma",
+                                      2.34828385973354, -0.0960185736017089, "", "debMiss1", "", "", ""))
+})
+
 test_that("Frequencies table matches", {
   options <- jaspTools::analysisOptions("Descriptives")
   options$variables <- "facGender"


### PR DESCRIPTION
Preview: 
<img width="1355" alt="image" src="https://github.com/jasp-stats/jaspDescriptives/assets/15704203/54904d0b-f2a9-438b-9e65-fc5011710606">

I was doubting what the best place is for these metrics - they could also be placed in the correlation/regression/reliability module. Also not sure yet about the right naming (e.g., could also remove "Association matrix" and append matrix to covariance and correlation). What do you think @EJWagenmakers and @juliuspfadt?

Related: https://github.com/jasp-stats/jasp-issues/issues/1364 