### PR TITLE
Use sturges in customizable histogram

### DIFF
--- a/R/descriptives.R
+++ b/R/descriptives.R
@@ -2517,6 +2517,7 @@ DescriptivesInternal <- function(jaspResults, dataset, options) {
                                                      xName = axeName,
                                                      groupingVariableName = options[["densityPlotSeparate"]],
                                                      groupingVariable = data[["separator"]],
+                                                     binWidthType = "sturges",
                                                      histogramPosition = options[["customHistogramPosition"]])
     if (options[["customHistogramPosition"]] == "identity")
       densPlot$plotObject$layers[[1]]$aes_params$alpha <- 1 - (options[["densityPlotTransparency"]]/100)


### PR DESCRIPTION
other method is pretty wonky for small sample sizes, for instance:
![image](https://github.com/jasp-stats/jaspDescriptives/assets/15704203/195e899e-6f5d-4a64-a321-d2e1b8a0d73d)
