### PR TITLE
prerelease fix

### DIFF
--- a/R/jaspPlotBuilder.R
+++ b/R/jaspPlotBuilder.R
@@ -48,6 +48,7 @@ jaspPlotBuilderInternal <- function(jaspResults, dataset, options) {
 }
 
 # ──────────────────────────────────────────────────────────────────────────────
+removeEmptyStrings <- function(x) Filter(nzchar, x)
 .plotBuilderReadData <- function(options) {
 
   datasetRMList    <- list()
@@ -59,9 +60,9 @@ jaspPlotBuilderInternal <- function(jaspResults, dataset, options) {
 
     if (identical(tab$isRM, "RM")) {
 
-      rm.vars    <- encodeColNames(tab$repeatedMeasuresCells)       |> nzchar() |> (\(x) tab$repeatedMeasuresCells[x])() |> encodeColNames()
-      factors    <- encodeColNames(tab$betweenSubjectFactors)       |> (\(x) x[nzchar(x)])()
-      covars     <- encodeColNames(tab$covariates)                  |> (\(x) x[nzchar(x)])()
+      rm.vars    <- encodeColNames(removeEmptyStrings(tab$repeatedMeasuresCells))
+      factors    <- encodeColNames(removeEmptyStrings(tab$betweenSubjectFactors))
+      covars     <- encodeColNames(removeEmptyStrings(tab$covariates))
 
       pointsize  <- encodeColNames(tab$sizeVariablePlotBuilder)
       labelVar   <- encodeColNames(tab$labelVariablePlotBuilder)
@@ -84,14 +85,14 @@ jaspPlotBuilderInternal <- function(jaspResults, dataset, options) {
       all.vars     <- c(factors, covars, rm.vars,
                         if (usePoint)  pointsize,
                         if (useLabel)  labelVar,
-                        if (useShape)  shapeVar) |> (\(x) x[nzchar(x)])()
+                        if (useShape)  shapeVar)
 
-      numeric.vars <- c(rm.vars, covars, if (usePoint) pointsize)   |> (\(x) x[nzchar(x)])()
+      numeric.vars <- c(rm.vars, covars, if (usePoint) pointsize)
 
       id.vars.long <- c(factors, covars,
                         if (usePoint)  pointsize,
                         if (useLabel)  labelVar,
-                        if (useShape)  shapeVar) |> (\(x) x[nzchar(x)])()
+                        if (useShape)  shapeVar)
 
       doListwise      <- isTRUE(tab$deleteNAListwise)
       excludeListwise <- if (doListwise)
@@ -100,7 +101,9 @@ jaspPlotBuilderInternal <- function(jaspResults, dataset, options) {
 
       ds_rm <- .readDataSetToEnd(
         columns.as.numeric  = numeric.vars,
-        columns.as.factor   = c(factors, if (useShape) shapeVar),
+        columns.as.factor   = c(factors,
+                                if (useShape) shapeVar,
+                                if (useLabel) labelVar),
         exclude.na.listwise = excludeListwise
       )
 

--- a/R/jaspPlotBuilder.R
+++ b/R/jaspPlotBuilder.R
@@ -75,7 +75,7 @@ jaspPlotBuilderInternal <- function(jaspResults, dataset, options) {
 
       expectedVars <- sum(vapply(rm.factors, function(f) length(f$levels), integer(1)))
       if (length(rm.vars) != expectedVars || any(rm.vars == ""))
-        .quitAnalysis("Please assign a variable to every RM factor (defined in Repeated Measures Factors) within Repeated Measures Cells.")
+        .quitAnalysis(gettext("Please assign a variable to every RM factor (defined in Repeated Measures Factors) within Repeated Measures Cells."))
 
       usePoint  <- nzchar(pointsize)
       useLabel  <- nzchar(labelVar)

--- a/R/jaspPlotBuilder.R
+++ b/R/jaspPlotBuilder.R
@@ -40,7 +40,6 @@ jaspPlotBuilderInternal <- function(jaspResults, dataset, options) {
   return()
 }
 
-
 # Init functions ----
 .plotBuilderInitOptions <- function(jaspResults, options) {
   # Initialize options if needed
@@ -48,78 +47,105 @@ jaspPlotBuilderInternal <- function(jaspResults, dataset, options) {
   options
 }
 
-
-
+# ──────────────────────────────────────────────────────────────────────────────
 .plotBuilderReadData <- function(options) {
 
   datasetRMList    <- list()
   datasetNonRMList <- list()
 
   for (tab in options$PlotBuilderTab) {
+
     plotId <- as.character(tab$value)
 
     if (identical(tab$isRM, "RM")) {
 
-      rm.vars <- encodeColNames(tab$repeatedMeasuresCells)
-      factors <- encodeColNames(tab$betweenSubjectFactors)
-      covars  <- encodeColNames(tab$covariates)
+      rm.vars    <- encodeColNames(tab$repeatedMeasuresCells)       |> nzchar() |> (\(x) tab$repeatedMeasuresCells[x])() |> encodeColNames()
+      factors    <- encodeColNames(tab$betweenSubjectFactors)       |> (\(x) x[nzchar(x)])()
+      covars     <- encodeColNames(tab$covariates)                  |> (\(x) x[nzchar(x)])()
 
-      rm.factors <- lapply(tab$repeatedMeasuresFactors, function(fct) {
-        fct$name   <- encodeColNames(fct$name)
-        fct$levels <- encodeColNames(fct$levels)
-        fct
+      pointsize  <- encodeColNames(tab$sizeVariablePlotBuilder)
+      labelVar   <- encodeColNames(tab$labelVariablePlotBuilder)
+      shapeVar   <- encodeColNames(tab$pointShapeVariable)
+
+      rm.factors <- lapply(tab$repeatedMeasuresFactors, function(f) {
+        f$name   <- encodeColNames(f$name)
+        f$levels <- encodeColNames(f$levels)
+        f
       })
 
       expectedVars <- sum(vapply(rm.factors, function(f) length(f$levels), integer(1)))
-      if (length(rm.vars) != expectedVars || any(rm.vars == "")) {
-        .quitAnalysis(
-          "Please assign variables from the available variables to each level of every Repeated Measures Factor (RM Factor)."
-        )
-      }
+      if (length(rm.vars) != expectedVars || any(rm.vars == ""))
+        .quitAnalysis("Please assign a variable to every RM factor (defined in Repeated Measures Factors) within Repeated Measures Cells.")
 
-      all.vars <- c(factors, covars, rm.vars)
+      usePoint  <- nzchar(pointsize)
+      useLabel  <- nzchar(labelVar)
+      useShape  <- nzchar(shapeVar)
+
+      all.vars     <- c(factors, covars, rm.vars,
+                        if (usePoint)  pointsize,
+                        if (useLabel)  labelVar,
+                        if (useShape)  shapeVar) |> (\(x) x[nzchar(x)])()
+
+      numeric.vars <- c(rm.vars, covars, if (usePoint) pointsize)   |> (\(x) x[nzchar(x)])()
+
+      id.vars.long <- c(factors, covars,
+                        if (usePoint)  pointsize,
+                        if (useLabel)  labelVar,
+                        if (useShape)  shapeVar) |> (\(x) x[nzchar(x)])()
+
+      doListwise      <- isTRUE(tab$deleteNAListwise)
+      excludeListwise <- if (doListwise)
+        setdiff(all.vars, c(labelVar, pointsize, shapeVar))
+      else NULL
 
       ds_rm <- .readDataSetToEnd(
-        columns.as.numeric  = c(rm.vars, covars),
-        columns.as.factor   = factors,
-        exclude.na.listwise = all.vars
+        columns.as.numeric  = numeric.vars,
+        columns.as.factor   = c(factors, if (useShape) shapeVar),
+        exclude.na.listwise = excludeListwise
       )
 
       missing.vars <- setdiff(rm.vars, colnames(ds_rm))
-      if (length(missing.vars) > 0) {
-        .quitAnalysis(
-          "Please assign variables from the available variables to each level of every Repeated Measures Factor (RM Factor)."
-        )
-      }
+      if (length(missing.vars) > 0)
+        .quitAnalysis("Please assign a variable to every RM factor (defined in Repeated Measures Factors) within Repeated Measures Cells.")
 
       ds_rm <- .shortToLong(
         ds_rm,
-        rm.factors,
-        rm.vars,
-        c(factors, covars),
+        rm.factors, rm.vars, id.vars.long,
         dependentName = "Value",
         subjectName   = "ID"
       )
 
       datasetRMList[[plotId]] <- ds_rm
-
     } else {
+
       plotCols <- unique(c(
         tab$variableXPlotBuilder,
         tab$variableYPlotBuilder,
         tab$variableColorPlotBuilder,
         tab$columnsvariableSplitPlotBuilder,
         tab$gridVariablePlotBuilder,
-        tab$rowsvariableSplitPlotBuilder
-      ))
-      encCols <- encodeColNames(plotCols)
+        tab$rowsvariableSplitPlotBuilder,
+        tab$sizeVariablePlotBuilder,
+        tab$labelVariablePlotBuilder,
+        tab$pointShapeVariable
 
-      ds <- .readDataSetToEnd(
-        columns = encCols,
-        exclude.na.listwise = plotCols
-      ) |>
-        dplyr::mutate(row_id = dplyr::row_number()) |>
-        na.omit()
+      ))
+
+      encCols <- encodeColNames(plotCols)
+      encCols <- encCols[nzchar(encCols)]
+
+      labelVar <- encodeColNames(tab$labelVariablePlotBuilder)
+
+      readCols <- if (length(encCols) > 0) encCols else NULL
+
+      ds <- .readDataSetToEnd(columns = readCols) |>
+        dplyr::mutate(row_id = dplyr::row_number())
+
+      dropVars <- setdiff(encCols, labelVar)
+      dropVars <- dropVars[nzchar(dropVars)]
+
+      if (length(dropVars) > 0)
+        ds <- tidyr::drop_na(ds, dplyr::all_of(dropVars))
 
       datasetNonRMList[[plotId]] <- ds
     }
@@ -130,8 +156,7 @@ jaspPlotBuilderInternal <- function(jaspResults, dataset, options) {
     datasetNonRMList = datasetNonRMList
   )
 }
-
-
+# ──────────────────────────────────────────────────────────────────────────────
 
 
 # Results functions ----
@@ -156,7 +181,7 @@ jaspPlotBuilderInternal <- function(jaspResults, dataset, options) {
 # the variables, only their names as encoded by JASP. But it is not a good idea to do the decoding
 # when reading the data, so we just do it in the ggplot mapping.
 
-
+#HELPER FUNCTION: Decode colnames ----
 addDecodedLabels <- function(p) {
   decodeFun <- function(x) decodeColNames(x)
 
@@ -166,7 +191,6 @@ addDecodedLabels <- function(p) {
     if (inherits(scale_obj, c("ScaleDiscrete", "ScaleOrdinal"))) {
       scale_obj$labels <- decodeFun
       scale_obj$drop   <- FALSE
-      # visszarakjuk a plot-ba
       p$scales$scales <- lapply(p$scales$scales, function(s) {
         if (identical(s$aesthetics, scale_obj$aesthetics)) scale_obj else s
       })
@@ -204,6 +228,44 @@ addDecodedLabels <- function(p) {
   p
 }
 
+#HELPER FUNCTION: jitter position ----
+
+.create_point_layer_func <- function(tab, shapeVar = NULL) {
+
+  shapeVar <- encodeColNames(tab[["pointShapeVariable"]])
+
+  function(p) {
+    argList <- list(
+      dodge_width   = tab[["pointDodgePlotBuilder"]],
+      jitter_height = tab[["jitterhPlotBuilder"]],
+      jitter_width  = tab[["jitterwPlotBuilder"]],
+      size          = tab[["pointsizePlotBuilder"]],
+      alpha         = tab[["alphaPlotBuilder"]],
+      white_border  = tab[["whiteBorder"]]
+    )
+
+    if (isTRUE(tab[["blackOutlineDataPoint"]]))
+      argList$color <- "black"
+
+    if (is.null(shapeVar) || !nzchar(shapeVar)) {
+      argList$shape <- ifelse(tab[["emptyCircles"]], 1, 21)
+    }
+
+    gp <- do.call(tidyplots::add_data_points_jitter, c(list(p), argList))
+
+    if (!is.null(shapeVar) && shapeVar %in% names(p$data)) {
+      for (i in seq_along(gp$layers)) {
+        if (inherits(gp$layers[[i]]$geom, "GeomPoint")) {
+          gp$layers[[i]]$aes_params$shape <- NULL
+          gp$layers[[i]]$mapping$shape    <- rlang::sym(shapeVar)
+        }
+      }
+    }
+
+    gp
+  }
+}
+
 # Creating plots -----
 
 .plotBuilderPlots <- function(dataset, options) {
@@ -213,7 +275,6 @@ addDecodedLabels <- function(p) {
 
   # Initialize the list to store plots
   updatedPlots <- list()
-
 
   for (tab in options[["PlotBuilderTab"]]) {
 
@@ -226,8 +287,8 @@ addDecodedLabels <- function(p) {
     }
 
     if (is.null(localData) ||
-      !is.data.frame(localData) ||
-      nrow(localData) == 0) {
+        !is.data.frame(localData) ||
+        nrow(localData) == 0) {
       next
     }
 
@@ -236,9 +297,12 @@ addDecodedLabels <- function(p) {
     xVar    <- encodeColNames(tab[["variableXPlotBuilder"]])
     yVar    <- encodeColNames(tab[["variableYPlotBuilder"]])
     rowsVar <- encodeColNames(tab[["rowsvariableSplitPlotBuilder"]])
+    sizeVar <- encodeColNames(tab[["sizeVariablePlotBuilder"]])
     colsVar <- encodeColNames(tab[["columnsvariableSplitPlotBuilder"]])
     colorVar <- NULL
     gridVar <- encodeColNames(tab[["gridVariablePlotBuilder"]])
+    labelVar <- encodeColNames(tab[["labelVariablePlotBuilder"]])
+    shapeVar <- encodeColNames(tab[["pointShapeVariable"]])
 
     if (identical(tab[["isRM"]], "RM")) {
       xVar      <- encodeColNames(tab[["xVarRM"]])
@@ -246,6 +310,7 @@ addDecodedLabels <- function(p) {
       rowsVar   <- encodeColNames(tab[["rowSplitRM"]])
       colsVar   <- encodeColNames(tab[["colSplitRM"]])
       gridVar   <- encodeColNames(tab[["gridVarRM"]])
+      sizeVar   <- encodeColNames(tab[["sizeVariablePlotBuilder"]])
     }
 
     colorBy <- tab[["colorByGroup"]]
@@ -283,8 +348,6 @@ addDecodedLabels <- function(p) {
         colorVar <- rowsVar
       }
     }
-
-
 
     # The next section is necessary because some functions do not work if the
     # variable is defined as ordinal within JASP.
@@ -335,11 +398,18 @@ addDecodedLabels <- function(p) {
       tidyplot_args$y <- rlang::sym(yVar)
     }
 
-    legend_position <- "none"
+    hasColor <- !is.null(colorVar) && nzchar(colorVar) && colorVar %in% colnames(localData)
+    hasSize  <- !is.null(sizeVar)  && nzchar(sizeVar)  && sizeVar  %in% colnames(localData)
+    hasShape <- !is.null(shapeVar) && nzchar(shapeVar) && shapeVar %in% colnames(localData)
+
+    legend_position <- if (hasColor || hasSize || hasShape) {
+      tab[["legendPosistionPlotBuilder"]]
+    } else {
+      "none"
+    }
 
     if (!is.na(colorVar) && colorVar %in% colnames(localData)) {
       tidyplot_args$color <- rlang::sym(colorVar)
-      legend_position <- tab[["legendPosistionPlotBuilder"]]
     }
 
     # Create the tidyplot object (tidyplots package)
@@ -367,947 +437,1042 @@ addDecodedLabels <- function(p) {
       }
     }
 
+    #Pre-calculation for determining the positions of jittered points----
+    #This is necessary so that the lines connecting the RM points can be
+    #ordered. Without it, they may lose their jittered position.
+    jittered_point_data <- NULL
+    if (tab[["connectRMPlotBuilder"]] && tab[["addDataPoint"]]) {
+      point_func <- .create_point_layer_func(tab, shapeVar)
+      temp_plot <- point_func(tidyplot_obj)
+      built_temp <- ggplot2::ggplot_build(temp_plot[[1]])
+      jittered_point_data <- built_temp$data[[1]]
+    }
+
+    layer_calls <- list()
+
     # Add data points (tidyplots::add_data_points_jitter)----
     if (tab[["addDataPoint"]]) {
 
-      argList <- list(
-        dodge_width   = tab[["pointDodgePlotBuilder"]],
-        jitter_height = tab[["jitterhPlotBuilder"]],
-        jitter_width  = tab[["jitterwPlotBuilder"]],
-        size          = tab[["pointsizePlotBuilder"]],
-        alpha         = tab[["alphaPlotBuilder"]],
-        shape         = ifelse(tab[["emptyCircles"]], 1, 21)
-      )
+      layer_calls$point <- function(p)
+      {
+        argList <- list(
+          dodge_width   = tab[["pointDodgePlotBuilder"]],
+          jitter_height = tab[["jitterhPlotBuilder"]],
+          jitter_width  = tab[["jitterwPlotBuilder"]],
+          size          = tab[["pointsizePlotBuilder"]],
+          alpha         = tab[["alphaPlotBuilder"]],
+          shape         = ifelse(tab[["emptyCircles"]], 1, 21),
+          white_border  = tab[["whiteBorder"]]
+        )
+        if (tab[["blackOutlineDataPoint"]])
+          argList$color <- "black"
 
-      if (tab[["blackOutlineDataPoint"]]) {
-        argList$color <- "black"
+        do.call(tidyplots::add_data_points_jitter, c(list(p), argList))
       }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_data_points_jitter,
-        c(list(tidyplot_obj), argList)
-      )
     }
 
-    # Add histogram (tidyplots::add_histogram)----
     if (tab[["addHistogram"]]) {
+      layer_calls$histogram <- function(p) {
+        fillvar <- NULL
+        if (!is.null(colorVar) && colorVar != "" && colorVar %in% names(localData)) {
+          fillvar <- colorVar
+        }
+        mapping_hist <- if (!is.null(fillvar)) {
+          ggplot2::aes(x = .data[[xVar]], y = ..count.., fill = .data[[fillvar]])
+        } else {
+          ggplot2::aes(x = .data[[xVar]], y = ..count..)
+        }
+        argList <- list(
+          mapping = mapping_hist,
+          bins = tab[["binsPlotBuilder"]],
+          alpha = tab[["alphaHistogramPlotBuilder"]],
+          position = "identity",
+          inherit.aes = TRUE
+        )
+        if (isTRUE(tab[["blackHistogramOutline"]])) {
+          argList$color <- "black"
+        } else {
+          argList$color <- NA
+        }
+        argList <- argList[!sapply(argList, is.null)]
+        ggcall <- p + do.call(ggplot2::geom_histogram, argList)
 
-      tidyplot_obj <- tryCatch(
-        {
-          if (!is.numeric(localData[[xVar]]) && !is.numeric(localData[[yVar]])) {
-            stop("The histogram requires that the X-Axis or Y-Axis Variable is continuous", call. = FALSE)
-          }
-          argList <- list(
-            bins  = tab[["binsPlotBuilder"]],
-            alpha = tab[["alphaHistogramPlotBuilder"]]
-          )
-          do.call(tidyplots::add_histogram, c(list(tidyplot_obj), argList))
-        },
-        error = function(e) {
-          stop(e$message, call. = FALSE)
-        })
+        titleValueY <- tab[["titleYPlotBuilder"]]
+        titleValueX <- tab[["titleXPlotBuilder"]]
+        if (!is.null(titleValueY) && nzchar(titleValueY)) {
+          ggcall <- ggcall + ggplot2::ylab(titleValueY)
+        }
+        if (!is.null(titleValueX) && nzchar(titleValueX)) {
+          ggcall <- ggcall + ggplot2::xlab(titleValueX)
+        }
+        return(ggcall)
+      }
     }
 
+
+    if (tab[["addDensity"]]) {
+      layer_calls$density <- function(p) {
+        mode <- tab[["densityOverlayMode"]]
+        fillvar <- NULL
+        if (!is.null(colorVar) && colorVar != "" && colorVar %in% names(localData)) {
+          fillvar <- colorVar
+        }
+        mapping_density <- if (!is.null(fillvar)) {
+          if (mode == "count") {
+            ggplot2::aes(x = .data[[xVar]], y = ..count.., fill = .data[[fillvar]], color = .data[[fillvar]])
+          } else {
+            ggplot2::aes(x = .data[[xVar]], y = ..scaled.., fill = .data[[fillvar]], color = .data[[fillvar]])
+          }
+        } else {
+          if (mode == "count") {
+            ggplot2::aes(x = .data[[xVar]], y = ..count..)
+          } else {
+            ggplot2::aes(x = .data[[xVar]], y = ..scaled..)
+          }
+        }
+        argList <- list(
+          mapping = mapping_density,
+          linewidth = tab[["lineWidthDensity"]],
+          alpha = tab[["alphaDensityPlotBuilder"]],
+          position = "identity",
+          inherit.aes = TRUE
+        )
+        if (tab[["blackDensityOutline"]]) {
+          argList$color <- "black"
+        }
+        argList <- argList[!sapply(argList, is.null)]
+        ggcall <- p + do.call(ggplot2::geom_density, argList)
+
+        titleValueY <- tab[["titleYPlotBuilder"]]
+        titleValueX <- tab[["titleXPlotBuilder"]]
+        if (!is.null(titleValueY) && nzchar(titleValueY)) {
+          ggcall <- ggcall + ggplot2::ylab(titleValueY)
+        }
+        if (!is.null(titleValueX) && nzchar(titleValueX)) {
+          ggcall <- ggcall + ggplot2::xlab(titleValueX)
+        }
+        return(ggcall)
+      }
+    }
 
 
     # Add boxplot (tidyplots::add_boxplot)----
     if (tab[["addBoxplot"]]) {
 
-      argList <- list(
-        dodge_width    = tab[["dodgeBoxplotPlotBuilder"]],
-        alpha          = tab[["alphaBoxplotPlotBuilder"]],
-        box_width      = tab[["widthBoxplotPlotBuilder"]],
-        linewidth      = tab[["widthLineBoxplotPlotBuilder"]],
-        whiskers_width = tab[["widthWhiskersPlotBuilder"]],
-        show_outliers  = tab[["outlierBoxplotPlotBuilder"]],
-        outlier.size   = tab[["outlierSizeBoxplotPlotBuilder"]],
-        coef           = tab[["outlierCoefBoxplotPlotBuilder"]]
-      )
-
-      if (tab[["blackOutlineBoxplot"]]) {
-        argList$color <- "black"
+      layer_calls$boxplot <- function(p) {
+        argList <- list(
+          dodge_width    = tab[["dodgeBoxplotPlotBuilder"]],
+          alpha          = tab[["alphaBoxplotPlotBuilder"]],
+          box_width      = tab[["widthBoxplotPlotBuilder"]],
+          linewidth      = tab[["widthLineBoxplotPlotBuilder"]],
+          whiskers_width = tab[["widthWhiskersPlotBuilder"]],
+          show_outliers  = tab[["outlierBoxplotPlotBuilder"]],
+          outlier.size   = tab[["outlierSizeBoxplotPlotBuilder"]],
+          coef           = tab[["outlierCoefBoxplotPlotBuilder"]]
+        )
+        if (tab[["blackOutlineBoxplot"]]) {
+          argList$color <- "black"
+        }
+        if (tab[["whiteOutlineBoxplot"]]) {
+          argList$color <- "white"
+        }
+        do.call(tidyplots::add_boxplot, c(list(p), argList))
       }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_boxplot,
-        c(list(tidyplot_obj), argList)
-      )
     }
+
 
     # Add violin (tidyplots::add_violin)----
     if (tab[["addViolin"]]) {
 
-      input_text <- tab[["drawQuantilesViolinPlotBuilder"]]
+      layer_calls$violin <- function(p) {
+        input_text <- tab[["drawQuantilesViolinPlotBuilder"]]
 
-      if (!grepl("^c\\(", input_text)) {
-        input_text <- paste0("c(", input_text, ")")
+        if (!grepl("^c\\(", input_text)) {
+          input_text <- paste0("c(", input_text, ")")
+        }
+
+        draw_quantiles <- eval(parse(text = input_text))
+
+        argList <- list(
+          draw_quantiles = draw_quantiles,
+          alpha          = tab[["alphaViolinPlotBuilder"]],
+          dodge_width    = tab[["dodgeViolinPlotBuilder"]],
+          linewidth      = tab[["linewidthViolinPlotBuilder"]],
+          trim           = tab[["trimViolinPlotBuilder"]],
+          scale          = tab[["scaleViolinPlotBuilder"]]
+        )
+
+        if (tab[["blackOutlineViolin"]]) {
+          argList$color <- "black"
+        }
+        if (tab[["whiteOutlineViolin"]]) {
+          argList$color <- "white"
+        }
+
+        do.call(tidyplots::add_violin, c(list(p), argList))
       }
-
-      draw_quantiles <- eval(parse(text = input_text))
-
-      argList <- list(
-        draw_quantiles = draw_quantiles,
-        alpha          = tab[["alphaViolinPlotBuilder"]],
-        dodge_width    = tab[["dodgeViolinPlotBuilder"]],
-        linewidth      = tab[["linewidthViolinPlotBuilder"]],
-        trim           = tab[["trimViolinPlotBuilder"]],
-        scale          = tab[["scaleViolinPlotBuilder"]]
-      )
-
-      if (tab[["blackOutlineViolin"]]) {
-        argList$color <- "black"
-      }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_violin,
-        c(list(tidyplot_obj), argList)
-      )
     }
 
     # Add Count Bar (tidyplots::add_count_bar)----
     if (tab[["addCountBar"]]) {
+      layer_calls$count_bar <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeCountBar"]],
+          width       = tab[["barwidthCountBar"]],
+          alpha       = tab[["alphaCountBar"]]
+        )
 
-      argList <- list(
-        dodge_width = tab[["dodgeCountBar"]],
-        width       = tab[["barwidthCountBar"]],
-        alpha       = tab[["alphaCountBar"]]
-      )
+        p <- do.call(tidyplots::add_count_bar, c(list(p), argList))
 
-      tidyplot_obj <- do.call(
-        tidyplots::add_count_bar,
-        c(list(tidyplot_obj), argList)
-      )
+        titleValueY <- tab[["titleYPlotBuilder"]]
+        if (!is.null(titleValueY) && titleValueY != "") {
+          p <- p |> tidyplots::adjust_y_axis_title(title = titleValueY)
+        }
 
-      # the address of the axes is basically defined at the end of the script,
-      # but for some reason it has to be valid for count geoms...
+        titleValueX <- tab[["titleXPlotBuilder"]]
+        if (!is.null(titleValueX) && titleValueX != "") {
+          p <- p |> tidyplots::adjust_x_axis_title(title = titleValueX)
+        }
 
-      titleValueY <- tab[["titleYPlotBuilder"]]
-      if (!is.null(titleValueY) && titleValueY != "") {
-        tidyplot_obj <- tidyplot_obj |>
-          tidyplots::adjust_y_axis_title(title = titleValueY)
-
+        p
       }
-
-      titleValueX <- tab[["titleXPlotBuilder"]]
-      if (!is.null(titleValueX) && titleValueX != "") {
-        tidyplot_obj <- tidyplot_obj |>
-          tidyplots::adjust_x_axis_title(title = titleValueX)
-      }
-
     }
 
     # Add Count Dash (tidyplots::add_count_dash)----
     if (tab[["addCountDash"]]) {
+      layer_calls$count_dash <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeCountDash"]],
+          linewidth   = tab[["linewidthCountDash"]],
+          width       = tab[["dashwidthCountDash"]],
+          alpha       = tab[["alphaCountDash"]]
+        )
 
-      argList <- list(
-        dodge_width = tab[["dodgeCountDash"]],
-        linewidth   = tab[["linewidthCountDash"]],
-        width       = tab[["dashwidthCountDash"]],
-        alpha       = tab[["alphaCountDash"]]
-      )
+        if (tab[["blackOutlineCountDash"]]) {
+          argList$color <- "black"
+          argList$fill  <- "black"
+        }
 
-      if (tab[["blackOutlineCountDash"]]) {
-        argList$color <- "black"
-        argList$fill  <- "black"
-      }
+        p <- do.call(tidyplots::add_count_dash, c(list(p), argList))
 
-      tidyplot_obj <- do.call(
-        tidyplots::add_count_dash,
-        c(list(tidyplot_obj), argList)
-      )
+        titleValueY <- tab[["titleYPlotBuilder"]]
+        if (!is.null(titleValueY) && titleValueY != "") {
+          p <- p |> tidyplots::adjust_y_axis_title(title = titleValueY)
+        }
 
-      # the address of the axes is basically defined at the end of the script,
-      # but for some reason it has to be valid for count geoms...
+        titleValueX <- tab[["titleXPlotBuilder"]]
+        if (!is.null(titleValueX) && titleValueX != "") {
+          p <- p |> tidyplots::adjust_x_axis_title(title = titleValueX)
+        }
 
-      titleValueY <- tab[["titleYPlotBuilder"]]
-      if (!is.null(titleValueY) && titleValueY != "") {
-        tidyplot_obj <- tidyplot_obj |>
-          tidyplots::adjust_y_axis_title(title = titleValueY)
-
-      }
-
-      titleValueX <- tab[["titleXPlotBuilder"]]
-      if (!is.null(titleValueX) && titleValueX != "") {
-        tidyplot_obj <- tidyplot_obj |>
-          tidyplots::adjust_x_axis_title(title = titleValueX)
+        p
       }
     }
 
     # Add Count Line (tidyplots::add_count_line)----
     if (tab[["addCountLine"]]) {
-      argList <- list(
-        dodge_width = tab[["dodgeCountLine"]],
-        linewidth   = tab[["linewidthCountLine"]],
-        alpha       = tab[["alphaCountLine"]]
-      )
-      if ((exists("colorBy") && colorBy %in% c("x", "y")) || tab[["blackOutlineCountLine"]]) {
-        argList$color <- "black"
-        argList$fill  <- "black"
-      }
-      if (exists("colorBy") && colorBy %in% c("x", "y")) {
-        argList$group <- 1
-      }
-      tidyplot_obj <- do.call(tidyplots::add_count_line, c(list(tidyplot_obj), argList))
-      titleValueY <- tab[["titleYPlotBuilder"]]
-      if (!is.null(titleValueY) && titleValueY != "") {
-        tidyplot_obj <- tidyplot_obj |> tidyplots::adjust_y_axis_title(title = titleValueY)
-      }
-      titleValueX <- tab[["titleXPlotBuilder"]]
-      if (!is.null(titleValueX) && titleValueX != "") {
-        tidyplot_obj <- tidyplot_obj |> tidyplots::adjust_x_axis_title(title = titleValueX)
+      layer_calls$count_line <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeCountLine"]],
+          linewidth   = tab[["linewidthCountLine"]],
+          alpha       = tab[["alphaCountLine"]]
+        )
+
+        if ((exists("colorBy") && colorBy %in% c("x", "y")) || tab[["blackOutlineCountLine"]]) {
+          argList$color <- "black"
+          argList$fill  <- "black"
+        }
+
+        if (exists("colorBy") && colorBy %in% c("x", "y")) {
+          argList$group <- 1
+        }
+
+        p <- do.call(tidyplots::add_count_line, c(list(p), argList))
+
+        titleValueY <- tab[["titleYPlotBuilder"]]
+        if (!is.null(titleValueY) && titleValueY != "") {
+          p <- p |> tidyplots::adjust_y_axis_title(title = titleValueY)
+        }
+
+        titleValueX <- tab[["titleXPlotBuilder"]]
+        if (!is.null(titleValueX) && titleValueX != "") {
+          p <- p |> tidyplots::adjust_x_axis_title(title = titleValueX)
+        }
+
+        p
       }
     }
 
     # Add Count Area (tidyplots::add_count_area)----
     if (tab[["addCountArea"]]) {
+      layer_calls$count_area <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeCountArea"]],
+          alpha       = tab[["alphaCountArea"]]
+        )
 
-      argList <- list(
-        dodge_width = tab[["dodgeCountArea"]],
-        alpha       = tab[["alphaCountArea"]]
-      )
+        p <- do.call(tidyplots::add_count_area, c(list(p), argList))
 
-      tidyplot_obj <- do.call(
-        tidyplots::add_count_area,
-        c(list(tidyplot_obj), argList)
-      )
+        titleValueY <- tab[["titleYPlotBuilder"]]
+        if (!is.null(titleValueY) && titleValueY != "") {
+          p <- p |> tidyplots::adjust_y_axis_title(title = titleValueY)
+        }
 
-      # the address of the axes is basically defined at the end of the script,
-      # but for some reason it has to be valid for count geoms...
+        titleValueX <- tab[["titleXPlotBuilder"]]
+        if (!is.null(titleValueX) && titleValueX != "") {
+          p <- p |> tidyplots::adjust_x_axis_title(title = titleValueX)
+        }
 
-      titleValueY <- tab[["titleYPlotBuilder"]]
-      if (!is.null(titleValueY) && titleValueY != "") {
-        tidyplot_obj <- tidyplot_obj |>
-          tidyplots::adjust_y_axis_title(title = titleValueY)
-
-      }
-
-      titleValueX <- tab[["titleXPlotBuilder"]]
-      if (!is.null(titleValueX) && titleValueX != "") {
-        tidyplot_obj <- tidyplot_obj |>
-          tidyplots::adjust_x_axis_title(title = titleValueX)
+        p
       }
     }
 
     # Add Count Value (tidyplots::add_count_value)----
     if (tab[["addCountValue"]]) {
+      layer_calls$count_value <- function(p) {
+        argList <- list(
+          fontsize = tab[["fontsizeCountValue"]],
+          accuracy = eval(parse(text = tab[["accuracyCountValue"]])),
+          alpha    = tab[["alphaCountValue"]],
+          hjust    = tab[["hjustCountValue"]],
+          vjust    = tab[["vjustCountValue"]]
+        )
 
-      argList <- list(
-        fontsize = tab[["fontsizeCountValue"]],
-        accuracy = eval(parse(text = tab[["accuracyCountValue"]])),
-        alpha    = tab[["alphaCountValue"]],
-        hjust    = tab[["hjustCountValue"]],
-        vjust    = tab[["vjustCountValue"]]
-      )
+        if (tab[["blackOutlineCountValue"]]) {
+          argList$color <- "black"
+          argList$fill  <- "black"
+        }
 
-      if (tab[["blackOutlineCountValue"]]) {
-        argList$color <- "black"
-        argList$fill  <- "black"
+        p <- do.call(tidyplots::add_count_value, c(list(p), argList))
+
+        titleValueY <- tab[["titleYPlotBuilder"]]
+        if (!is.null(titleValueY) && titleValueY != "") {
+          p <- p |> tidyplots::adjust_y_axis_title(title = titleValueY)
+        }
+
+        titleValueX <- tab[["titleXPlotBuilder"]]
+        if (!is.null(titleValueX) && titleValueX != "") {
+          p <- p |> tidyplots::adjust_x_axis_title(title = titleValueX)
+        }
+
+        p
       }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_count_value,
-        c(list(tidyplot_obj), argList)
-      )
-
-      # the address of the axes is basically defined at the end of the script,
-      # but for some reason it has to be valid for count geoms...
-
-      titleValueY <- tab[["titleYPlotBuilder"]]
-      if (!is.null(titleValueY) && titleValueY != "") {
-        tidyplot_obj <- tidyplot_obj |>
-          tidyplots::adjust_y_axis_title(title = titleValueY)
-
-      }
-
-      titleValueX <- tab[["titleXPlotBuilder"]]
-      if (!is.null(titleValueX) && titleValueX != "") {
-        tidyplot_obj <- tidyplot_obj |>
-          tidyplots::adjust_x_axis_title(title = titleValueX)
-      }
-
     }
 
     # Add Sum Bar (tidyplots::add_sum_bar)----
     if (tab[["addSumBar"]]) {
-
-      argList <- list(
-        dodge_width = tab[["dodgeSumBar"]],
-        width       = tab[["widthSumBar"]],
-        alpha       = tab[["alphaSumBar"]]
-      )
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_sum_bar,
-        c(list(tidyplot_obj), argList)
-      )
+      layer_calls$sum_bar <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeSumBar"]],
+          width       = tab[["widthSumBar"]],
+          alpha       = tab[["alphaSumBar"]]
+        )
+        do.call(tidyplots::add_sum_bar, c(list(p), argList))
+      }
     }
 
     # Add Sum Dash (tidyplots::add_sum_dash)----
     if (tab[["addSumDash"]]) {
+      layer_calls$sum_dash <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeSumDash"]],
+          width       = tab[["widthSumDash"]],
+          linewidth   = tab[["linewidthSumDash"]],
+          alpha       = tab[["alphaSumDash"]]
+        )
 
-      argList <- list(
-        dodge_width = tab[["dodgeSumDash"]],
-        width       = tab[["widthSumDash"]],
-        linewidth   = tab[["linewidthSumDash"]],
-        alpha       = tab[["alphaSumDash"]]
-      )
+        if (tab[["blackOutlineSumDash"]]) {
+          argList$color <- "black"
+          argList$fill  <- "black"
+        }
 
-      if (tab[["blackOutlineSumDash"]]) {
-        argList$color <- "black"
-        argList$fill  <- "black"
+        do.call(tidyplots::add_sum_dash, c(list(p), argList))
       }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_sum_dash,
-        c(list(tidyplot_obj), argList)
-      )
     }
-
-
 
     # Add Sum Value (tidyplots::add_sum_value)----
     if (tab[["addSumValue"]]) {
+      layer_calls$sum_value <- function(p) {
+        argList <- list(
+          fontsize = tab[["fontsizeSumValue"]],
+          accuracy = eval(parse(text = tab[["accuracySumValue"]])),
+          alpha    = tab[["alphaSumValue"]],
+          hjust    = tab[["hjustSumValue"]],
+          vjust    = tab[["vjustSumValue"]]
+        )
 
-      argList <- list(
-        fontsize = tab[["fontsizeSumValue"]],
-        accuracy = eval(parse(text = tab[["accuracySumValue"]])),
-        alpha    = tab[["alphaSumValue"]],
-        hjust    = tab[["hjustSumValue"]],
-        vjust    = tab[["vjustSumValue"]]
-      )
+        if (tab[["blackOutlineSumValue"]]) {
+          argList$color <- "black"
+          argList$fill  <- "black"
+        }
 
-      if (tab[["blackOutlineSumValue"]]) {
-        argList$color <- "black"
-        argList$fill  <- "black"
+        do.call(tidyplots::add_sum_value, c(list(p), argList))
       }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_sum_value,
-        c(list(tidyplot_obj), argList)
-      )
     }
 
     # Add Sum Line (tidyplots::add_sum_line)----
     if (tab[["addSumLine"]]) {
-      argList <- list(
-        dodge_width = tab[["dodgeSumLine"]],
-        linewidth   = tab[["linewidthSumLine"]],
-        alpha       = tab[["alphaSumLine"]]
-      )
-      if ((exists("colorBy") && colorBy %in% c("x", "y")) || tab[["blackOutlineSumLine"]]) {
-        argList$color <- "black"
-        argList$fill  <- "black"
+      layer_calls$sum_line <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeSumLine"]],
+          linewidth   = tab[["linewidthSumLine"]],
+          alpha       = tab[["alphaSumLine"]]
+        )
+
+        if ((exists("colorBy") && colorBy %in% c("x", "y")) || tab[["blackOutlineSumLine"]]) {
+          argList$color <- "black"
+          argList$fill  <- "black"
+        }
+
+        if (exists("colorBy") && colorBy %in% c("x", "y")) {
+          argList$group <- 1
+        }
+
+        do.call(tidyplots::add_sum_line, c(list(p), argList))
       }
-      if (exists("colorBy") && colorBy %in% c("x", "y")) {
-        argList$group <- 1
-      }
-      tidyplot_obj <- do.call(tidyplots::add_sum_line, c(list(tidyplot_obj), argList))
     }
 
     # Add Sum Area (tidyplots::add_sum_area)----
     if (tab[["addSumArea"]]) {
-
-      argList <- list(
-        dodge_width = tab[["dodgeSumArea"]],
-        linewidth   = tab[["linewidthSumArea"]],
-        alpha       = tab[["alphaSumArea"]]
-      )
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_sum_area,
-        c(list(tidyplot_obj), argList)
-      )
+      layer_calls$sum_area <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeSumArea"]],
+          linewidth   = tab[["linewidthSumArea"]],
+          alpha       = tab[["alphaSumArea"]]
+        )
+        do.call(tidyplots::add_sum_area, c(list(p), argList))
+      }
     }
 
+
     # Add proportion bar and area ####
+
     # For Bar Stack, use the single "addBarStack" option.
     if (tab[["addBarStack"]]) {
-      # Retrieve the proportion mode from the radio button group:
-      # It should be "absolute" or "relative".
-      mode <- tab[["propMode"]]
+      layer_calls$barstack <- function(p) {
+        mode <- tab[["propMode"]]
 
-      # Create the common argument list for the bar stack.
-      argList <- list(
-        reverse = tab[["reverseBarStack"]],
-        alpha   = tab[["alphaBarStack"]]
-      )
-
-      # Depending on the selected mode, call the appropriate function.
-      if (mode == "absolute") {
-        tidyplot_obj <- do.call(
-          tidyplots::add_barstack_absolute,
-          c(list(tidyplot_obj), argList)
+        argList <- list(
+          reverse = tab[["reverseBarStack"]],
+          alpha   = tab[["alphaBarStack"]]
         )
+
+        if (mode == "absolute") {
+          p <- do.call(tidyplots::add_barstack_absolute, c(list(p), argList))
+        } else if (mode == "relative") {
+          p <- do.call(tidyplots::add_barstack_relative, c(list(p), argList))
+        }
 
         titleValueY <- tab[["titleYPlotBuilder"]]
         if (!is.null(titleValueY) && titleValueY != "") {
-          tidyplot_obj <- tidyplot_obj |>
-            tidyplots::adjust_y_axis_title(title = titleValueY)
-
+          p <- p |> tidyplots::adjust_y_axis_title(title = titleValueY)
         }
 
         titleValueX <- tab[["titleXPlotBuilder"]]
         if (!is.null(titleValueX) && titleValueX != "") {
-          tidyplot_obj <- tidyplot_obj |>
-            tidyplots::adjust_x_axis_title(title = titleValueX)
+          p <- p |> tidyplots::adjust_x_axis_title(title = titleValueX)
         }
 
-      } else if (mode == "relative") {
-        tidyplot_obj <- do.call(
-          tidyplots::add_barstack_relative,
-          c(list(tidyplot_obj), argList)
-        )
-
-        titleValueY <- tab[["titleYPlotBuilder"]]
-        if (!is.null(titleValueY) && titleValueY != "") {
-          tidyplot_obj <- tidyplot_obj |>
-            tidyplots::adjust_y_axis_title(title = titleValueY)
-
-        }
-
-        titleValueX <- tab[["titleXPlotBuilder"]]
-        if (!is.null(titleValueX) && titleValueX != "") {
-          tidyplot_obj <- tidyplot_obj |>
-            tidyplots::adjust_x_axis_title(title = titleValueX)
-        }
-
+        p
       }
     }
 
     # For Area Stack, use the single "addAreaStack" option.
     if (tab[["addAreaStack"]]) {
-      # Retrieve the proportion mode ("absolute" or "relative").
-      mode <- tab[["propMode"]]
+      layer_calls$areastack <- function(p) {
+        mode <- tab[["propMode"]]
 
-      # Create the common argument list for the area stack.
-      argList <- list(
-        reverse    = tab[["reverseAreaStack"]],
-        alpha      = tab[["alphaAreaStack"]],
-        linewidth  = tab[["linewidthAreaStack"]],
-        replace_na = tab[["replaceNaAreaStack"]]
-      )
+        argList <- list(
+          reverse    = tab[["reverseAreaStack"]],
+          alpha      = tab[["alphaAreaStack"]],
+          linewidth  = tab[["linewidthAreaStack"]],
+          replace_na = tab[["replaceNaAreaStack"]]
+        )
 
-      # Depending on the selected mode, call the appropriate function.
-      if (mode == "absolute") {
-        tidyplot_obj <- do.call(
-          tidyplots::add_areastack_absolute,
-          c(list(tidyplot_obj), argList)
-        )
-      } else if (mode == "relative") {
-        tidyplot_obj <- do.call(
-          tidyplots::add_areastack_relative,
-          c(list(tidyplot_obj), argList)
-        )
+        if (mode == "absolute") {
+          do.call(tidyplots::add_areastack_absolute, c(list(p), argList))
+        } else if (mode == "relative") {
+          do.call(tidyplots::add_areastack_relative, c(list(p), argList))
+        } else {
+          p  # fallback: return unchanged if invalid mode
+        }
       }
     }
 
+
     # Add Mean Bar (tidyplots::add_mean_bar)----
     if (tab[["addMeanBar"]]) {
-
-      argList <- list(
-        dodge_width = tab[["dodgeMeanBar"]],
-        alpha       = tab[["alphaMeanBar"]],
-        width       = tab[["widthMeanBar"]]
-      )
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_mean_bar,
-        c(list(tidyplot_obj), argList)
-      )
+      layer_calls$mean_bar <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeMeanBar"]],
+          alpha       = tab[["alphaMeanBar"]],
+          width       = tab[["widthMeanBar"]]
+        )
+        do.call(tidyplots::add_mean_bar, c(list(p), argList))
+      }
     }
 
     # Add Mean Dash (tidyplots::add_mean_dash)----
     if (tab[["addMeanDash"]]) {
+      layer_calls$mean_dash <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeMeanDash"]],
+          alpha       = tab[["alphaMeanDash"]],
+          width       = tab[["dashwidthMeanDash"]],
+          linewidth   = tab[["linewidthMeanDash"]]
+        )
 
-      argList <- list(
-        dodge_width = tab[["dodgeMeanDash"]],
-        alpha       = tab[["alphaMeanDash"]],
-        width       = tab[["dashwidthMeanDash"]],
-        linewidth   = tab[["linewidthMeanDash"]]
-      )
+        if (tab[["blackOutlineMeanDash"]]) {
+          argList$color <- "black"
+          argList$fill  <- "black"
+        }
 
-      if (tab[["blackOutlineMeanDash"]]) {
-        argList$color <- "black"
-        argList$fill  <- "black"
+        do.call(tidyplots::add_mean_dash, c(list(p), argList))
       }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_mean_dash,
-        c(list(tidyplot_obj), argList)
-      )
     }
 
     # Add Mean Line (tidyplots::add_mean_line)----
     if (tab[["addMeanLine"]]) {
+      layer_calls$mean_line <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeMeanLine"]],
+          alpha       = tab[["alphaMeanLine"]],
+          linewidth   = tab[["linewidthMeanLine"]]
+        )
 
-      argList <- list(
-        dodge_width = tab[["dodgeMeanLine"]],
-        alpha       = tab[["alphaMeanLine"]],
-        linewidth   = tab[["linewidthMeanLine"]]
-      )
+        if ((exists("colorBy") && colorBy %in% c("x", "y")) || tab[["blackOutlineMeanLine"]]) {
+          argList$color <- "black"
+          argList$fill  <- "black"
+        }
 
-      if ((exists("colorBy") && colorBy %in% c("x", "y")) || tab[["blackOutlineMeanLine"]]) {
-        argList$color <- "black"
-        argList$fill  <- "black"
+        if (exists("colorBy") && colorBy %in% c("x", "y")) {
+          argList$group <- 1
+        }
+
+        do.call(tidyplots::add_mean_line, c(list(p), argList))
       }
-
-      if (exists("colorBy") && colorBy %in% c("x", "y")) {
-        argList$group <- 1
-      }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_mean_line,
-        c(list(tidyplot_obj), argList)
-      )
     }
-
 
     # Add Mean Area (tidyplots::add_mean_area)----
     if (tab[["addMeanArea"]]) {
-
-      argList <- list(
-        dodge_width = tab[["dodgeMeanArea"]],
-        alpha       = tab[["alphaMeanArea"]],
-        linewidth   = tab[["linewidthMeanArea"]]
-      )
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_mean_area,
-        c(list(tidyplot_obj), argList)
-      )
+      layer_calls$mean_area <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeMeanArea"]],
+          alpha       = tab[["alphaMeanArea"]],
+          linewidth   = tab[["linewidthMeanArea"]]
+        )
+        do.call(tidyplots::add_mean_area, c(list(p), argList))
+      }
     }
 
     # Add Mean Value (tidyplots::add_mean_value)----
     if (tab[["addMeanValue"]]) {
+      layer_calls$mean_value <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeMeanValue"]],
+          alpha       = tab[["alphaMeanValue"]],
+          fontsize    = tab[["fontsizeMeanValue"]],
+          accuracy    = eval(parse(text = tab[["accuracyMeanValue"]])),
+          hjust       = tab[["hjustMeanValue"]],
+          vjust       = tab[["vjustMeanValue"]]
+        )
 
-      argList <- list(
-        dodge_width = tab[["dodgeMeanValue"]],
-        alpha       = tab[["alphaMeanValue"]],
-        fontsize    = tab[["fontsizeMeanValue"]],
-        accuracy    = eval(parse(text = tab[["accuracyMeanValue"]])),
-        hjust       = tab[["hjustMeanValue"]],
-        vjust       = tab[["vjustMeanValue"]]
-      )
+        if (tab[["blackOutlineMeanValue"]]) {
+          argList$color <- "black"
+          argList$fill  <- "black"
+        }
 
-      if (tab[["blackOutlineMeanValue"]]) {
-        argList$color <- "black"
-        argList$fill  <- "black"
+        do.call(tidyplots::add_mean_value, c(list(p), argList))
       }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_mean_value,
-        c(list(tidyplot_obj), argList)
-      )
     }
 
     # Add Median Bar (tidyplots::add_median_bar)----
     if (tab[["addMedianBar"]]) {
-
-      argList <- list(
-        dodge_width = tab[["dodgeMedianBar"]],
-        alpha       = tab[["alphaMedianBar"]],
-        width       = tab[["widthMedianBar"]]
-      )
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_median_bar,
-        c(list(tidyplot_obj), argList)
-      )
+      layer_calls$median_bar <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeMedianBar"]],
+          alpha       = tab[["alphaMedianBar"]],
+          width       = tab[["widthMedianBar"]]
+        )
+        do.call(tidyplots::add_median_bar, c(list(p), argList))
+      }
     }
 
     # Add Median Dash (tidyplots::add_median_dash)----
     if (tab[["addMedianDash"]]) {
+      layer_calls$median_dash <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeMedianDash"]],
+          width       = tab[["dashwidthMedianDash"]],
+          linewidth   = tab[["linewidthMedianDash"]],
+          alpha       = tab[["alphaMedianDash"]]
+        )
 
-      argList <- list(
-        dodge_width = tab[["dodgeMedianDash"]],
-        width       = tab[["dashwidthMedianDash"]],
-        linewidth   = tab[["linewidthMedianDash"]],
-        alpha       = tab[["alphaMedianDash"]]
-      )
+        if (tab[["blackOutlineMedianDash"]]) {
+          argList$color <- "black"
+          argList$fill  <- "black"
+        }
 
-      if (tab[["blackOutlineMedianDash"]]) {
-        argList$color <- "black"
-        argList$fill  <- "black"
+        do.call(tidyplots::add_median_dash, c(list(p), argList))
       }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_median_dash,
-        c(list(tidyplot_obj), argList)
-      )
     }
 
     # Add Median Line (tidyplots::add_median_line)----
     if (tab[["addMedianLine"]]) {
-      argList <- list(
-        dodge_width = tab[["dodgeMedianLine"]],
-        linewidth   = tab[["linewidthMedianLine"]],
-        alpha       = tab[["alphaMedianLine"]]
-      )
-      if ((exists("colorBy") && colorBy %in% c("x", "y")) || tab[["blackOutlineMedianLine"]]) {
-        argList$color <- "black"
-        argList$fill  <- "black"
-      }
-      if (exists("colorBy") && colorBy %in% c("x", "y")) {
-        argList$group <- 1
-      }
-      tidyplot_obj <- do.call(tidyplots::add_median_line, c(list(tidyplot_obj), argList))
-    }
+      layer_calls$median_line <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeMedianLine"]],
+          linewidth   = tab[["linewidthMedianLine"]],
+          alpha       = tab[["alphaMedianLine"]]
+        )
 
+        if ((exists("colorBy") && colorBy %in% c("x", "y")) || tab[["blackOutlineMedianLine"]]) {
+          argList$color <- "black"
+          argList$fill  <- "black"
+        }
+
+        if (exists("colorBy") && colorBy %in% c("x", "y")) {
+          argList$group <- 1
+        }
+
+        do.call(tidyplots::add_median_line, c(list(p), argList))
+      }
+    }
 
     # Add Median Area (tidyplots::add_median_area)----
     if (tab[["addMedianArea"]]) {
-
-      argList <- list(
-        dodge_width = tab[["dodgeMedianArea"]],
-        linewidth   = tab[["linewidthMedianArea"]],
-        alpha       = tab[["alphaMedianArea"]]
-      )
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_median_area,
-        c(list(tidyplot_obj), argList)
-      )
+      layer_calls$median_area <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeMedianArea"]],
+          linewidth   = tab[["linewidthMedianArea"]],
+          alpha       = tab[["alphaMedianArea"]]
+        )
+        do.call(tidyplots::add_median_area, c(list(p), argList))
+      }
     }
 
     # Add Median Value (tidyplots::add_median_value)----
     if (tab[["addMedianValue"]]) {
+      layer_calls$median_value <- function(p) {
+        argList <- list(
+          fontsize = tab[["fontsizeMedianValue"]],
+          accuracy = eval(parse(text = tab[["accuracyMedianValue"]])),
+          alpha    = tab[["alphaMedianValue"]],
+          hjust    = tab[["hjustMedianValue"]],
+          vjust    = tab[["vjustMedianValue"]]
+        )
 
-      argList <- list(
-        fontsize = tab[["fontsizeMedianValue"]],
-        accuracy = eval(parse(text = tab[["accuracyMedianValue"]])),
-        alpha    = tab[["alphaMedianValue"]],
-        hjust    = tab[["hjustMedianValue"]],
-        vjust    = tab[["vjustMedianValue"]]
-      )
+        if (tab[["blackOutlineMedianValue"]]) {
+          argList$color <- "black"
+          argList$fill  <- "black"
+        }
 
-      if (tab[["blackOutlineMedianValue"]]) {
-        argList$color <- "black"
-        argList$fill  <- "black"
+        do.call(tidyplots::add_median_value, c(list(p), argList))
       }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_median_value,
-        c(list(tidyplot_obj), argList)
-      )
     }
+
 
     # Add SEM Error Bar (tidyplots::add_sem_errorbar)----
     if (tab[["addSEMErrorBar"]]) {
-
-      argList <- list(
-        dodge_width = tab[["dodgeSEMErrorBar"]],
-        width       = tab[["widthSEMErrorBar"]],
-        linewidth   = tab[["linewidthSEMErrorBar"]],
-        alpha       = tab[["transparencySDErrorBar"]]
-      )
-
-      if (tab[["blackOutlineSEMErrorBar"]]) {
-        argList$color <- "black"
-        argList$fill  <- "black"
+      layer_calls$sem_errorbar <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeSEMErrorBar"]],
+          width       = tab[["widthSEMErrorBar"]],
+          linewidth   = tab[["linewidthSEMErrorBar"]],
+          alpha       = tab[["transparencySDErrorBar"]]
+        )
+        if (tab[["blackOutlineSEMErrorBar"]]) {
+          argList$color <- "black"
+          argList$fill  <- "black"
+        }
+        do.call(tidyplots::add_sem_errorbar, c(list(p), argList))
       }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_sem_errorbar,
-        c(list(tidyplot_obj), argList)
-      )
     }
 
     # Add Range Error Bar (tidyplots::add_range_errorbar)----
     if (tab[["addRangeErrorBar"]]) {
-
-      argList <- list(
-        dodge_width = tab[["dodgeRangeErrorBar"]],
-        width       = tab[["widthRangeErrorBar"]],
-        linewidth   = tab[["linewidthRangeErrorBar"]],
-        alpha       = tab[["transparencyRangeErrorBar"]]
-      )
-
-      if (tab[["blackOutlineRangeErrorBar"]]) {
-        argList$color <- "black"
-        argList$fill  <- "black"
+      layer_calls$range_errorbar <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeRangeErrorBar"]],
+          width       = tab[["widthRangeErrorBar"]],
+          linewidth   = tab[["linewidthRangeErrorBar"]],
+          alpha       = tab[["transparencyRangeErrorBar"]]
+        )
+        if (tab[["blackOutlineRangeErrorBar"]]) {
+          argList$color <- "black"
+          argList$fill  <- "black"
+        }
+        do.call(tidyplots::add_range_errorbar, c(list(p), argList))
       }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_range_errorbar,
-        c(list(tidyplot_obj), argList)
-      )
     }
 
     # Add SD Error Bar (tidyplots::add_sd_errorbar)----
     if (tab[["addSDErrorBar"]]) {
-
-      argList <- list(
-        dodge_width = tab[["dodgeSDErrorBar"]],
-        width       = tab[["widthSDErrorBar"]],
-        linewidth   = tab[["linewidthSDErrorBar"]],
-        alpha       = tab[["transparencySDErrorBar"]]
-      )
-
-      if (tab[["blackOutlineSDErrorBar"]]) {
-        argList$color <- "black"
-        argList$fill  <- "black"
+      layer_calls$sd_errorbar <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeSDErrorBar"]],
+          width       = tab[["widthSDErrorBar"]],
+          linewidth   = tab[["linewidthSDErrorBar"]],
+          alpha       = tab[["transparencySDErrorBar"]]
+        )
+        if (tab[["blackOutlineSDErrorBar"]]) {
+          argList$color <- "black"
+          argList$fill  <- "black"
+        }
+        do.call(tidyplots::add_sd_errorbar, c(list(p), argList))
       }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_sd_errorbar,
-        c(list(tidyplot_obj), argList)
-      )
     }
 
     # Add 95% CI Error Bar (tidyplots::add_ci95_errorbar)----
     if (tab[["addCI95ErrorBar"]]) {
-
-      argList <- list(
-        dodge_width = tab[["dodgeCI95ErrorBar"]],
-        width       = tab[["widthCI95ErrorBar"]],
-        linewidth   = tab[["linewidthCI95ErrorBar"]],
-        alpha       = tab[["transparencyCI95ErrorBar"]]
-      )
-
-      if (tab[["blackOutlineCI95ErrorBar"]]) {
-        argList$color <- "black"
-        argList$fill  <- "black"
+      layer_calls$ci95_errorbar <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeCI95ErrorBar"]],
+          width       = tab[["widthCI95ErrorBar"]],
+          linewidth   = tab[["linewidthCI95ErrorBar"]],
+          alpha       = tab[["transparencyCI95ErrorBar"]]
+        )
+        if (tab[["blackOutlineCI95ErrorBar"]]) {
+          argList$color <- "black"
+          argList$fill  <- "black"
+        }
+        do.call(tidyplots::add_ci95_errorbar, c(list(p), argList))
       }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_ci95_errorbar,
-        c(list(tidyplot_obj), argList)
-      )
     }
 
     # Add SEM Ribbon (tidyplots::add_sem_ribbon)----
     if (tab[["addSemRibbon"]]) {
-
-      argList <- list(
-        dodge_width = 0.8,
-        alpha       = tab[["alphaSemRibbon"]]
-      )
-
-      if (tab[["blackOutlineSemRibbon"]]) {
-        argList$color <- "black"
-        argList$fill  <- "black"
+      layer_calls$sem_ribbon <- function(p) {
+        argList <- list(
+          dodge_width = 0.8,
+          alpha       = tab[["alphaSemRibbon"]]
+        )
+        if (tab[["blackOutlineSemRibbon"]]) {
+          argList$color <- "black"
+          argList$fill  <- "black"
+        }
+        do.call(tidyplots::add_sem_ribbon, c(list(p), argList))
       }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_sem_ribbon,
-        c(list(tidyplot_obj), argList)
-      )
     }
 
     # Add Range Ribbon (tidyplots::add_range_ribbon)----
     if (tab[["addRangeRibbon"]]) {
-
-      argList <- list(
-        dodge_width = 0.8,
-        alpha       = tab[["alphaRangeRibbon"]]
-      )
-
-      if (tab[["blackOutlineRangeRibbon"]]) {
-        argList$color <- "black"
-        argList$fill  <- "black"
+      layer_calls$range_ribbon <- function(p) {
+        argList <- list(
+          dodge_width = 0.8,
+          alpha       = tab[["alphaRangeRibbon"]]
+        )
+        if (tab[["blackOutlineRangeRibbon"]]) {
+          argList$color <- "black"
+          argList$fill  <- "black"
+        }
+        do.call(tidyplots::add_range_ribbon, c(list(p), argList))
       }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_range_ribbon,
-        c(list(tidyplot_obj), argList)
-      )
     }
 
     # Add SD Ribbon (tidyplots::add_sd_ribbon)----
     if (tab[["addSdRibbon"]]) {
-
-      argList <- list(
-        dodge_width = 0.8,
-        alpha       = tab[["alphaSdRibbon"]]
-      )
-
-      if (tab[["blackOutlineSdRibbon"]]) {
-        argList$color <- "black"
-        argList$fill  <- "black"
+      layer_calls$sd_ribbon <- function(p) {
+        argList <- list(
+          dodge_width = 0.8,
+          alpha       = tab[["alphaSdRibbon"]]
+        )
+        if (tab[["blackOutlineSdRibbon"]]) {
+          argList$color <- "black"
+          argList$fill  <- "black"
+        }
+        do.call(tidyplots::add_sd_ribbon, c(list(p), argList))
       }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_sd_ribbon,
-        c(list(tidyplot_obj), argList)
-      )
     }
 
     # Add 95% CI Ribbon (tidyplots::add_ci95_ribbon)----
     if (tab[["addCi95Ribbon"]]) {
-
-      argList <- list(
-        dodge_width = 0.8,
-        alpha       = tab[["alphaCi95Ribbon"]]
-      )
-
-      if (tab[["blackOutlineCi95Ribbon"]]) {
-        argList$color <- "black"
-        argList$fill  <- "black"
+      layer_calls$ci95_ribbon <- function(p) {
+        argList <- list(
+          dodge_width = 0.8,
+          alpha       = tab[["alphaCi95Ribbon"]]
+        )
+        if (tab[["blackOutlineCi95Ribbon"]]) {
+          argList$color <- "black"
+          argList$fill  <- "black"
+        }
+        do.call(tidyplots::add_ci95_ribbon, c(list(p), argList))
       }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_ci95_ribbon,
-        c(list(tidyplot_obj), argList)
-      )
     }
+
 
     # Add Count Dot (tidyplots::add_count_dot)----
     if (tab[["addCountDot"]]) {
-
-      argList <- list(
-        dodge_width = tab[["dodgeCountDot"]],
-        size        = tab[["sizeCountDot"]],
-        alpha       = tab[["alphaCountDot"]],
-        shape       = 21
-      )
-
-      if (tab[["blackOutlineCountDot"]]) {
-        argList$color <- "black"
+      layer_calls$count_dot <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeCountDot"]],
+          size        = tab[["sizeCountDot"]],
+          alpha       = tab[["alphaCountDot"]],
+          shape       = 21
+        )
+        if (tab[["blackOutlineCountDot"]]) {
+          argList$color <- "black"
+        }
+        if (tab[["whiteOutlineCountDot"]]) {
+          argList$color <- "white"
+        }
+        do.call(tidyplots::add_count_dot, c(list(p), argList))
       }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_count_dot,
-        c(list(tidyplot_obj), argList)
-      )
     }
 
     # Add Sum Dot (tidyplots::add_sum_dot)----
     if (tab[["addSumDot"]]) {
-
-      argList <- list(
-        dodge_width = tab[["dodgeSumDot"]],
-        size        = tab[["sizeSumDot"]],
-        alpha       = tab[["alphaSumDot"]],
-        shape       = 21
-      )
-
-      if (tab[["blackOutlineSumDot"]]) {
-        argList$color <- "black"
+      layer_calls$sum_dot <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeSumDot"]],
+          size        = tab[["sizeSumDot"]],
+          alpha       = tab[["alphaSumDot"]],
+          shape       = 21
+        )
+        if (tab[["blackOutlineSumDot"]]) {
+          argList$color <- "black"
+        }
+        if (tab[["whiteOutlineSumDot"]]) {
+          argList$color <- "white"
+        }
+        do.call(tidyplots::add_sum_dot, c(list(p), argList))
       }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_sum_dot,
-        c(list(tidyplot_obj), argList)
-      )
     }
 
     # Add Mean Dot (tidyplots::add_mean_dot)----
     if (tab[["addMeanDot"]]) {
+      layer_calls$mean_dot <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeMeanDot"]],
+          alpha       = tab[["alphaMeanDot"]],
+          size        = tab[["sizeMeanDot"]],
+          shape       = 21
+        )
+        if (tab[["blackOutlineMeanDot"]]) {
+          argList$color <- "black"
+        }
+        if (tab[["whiteOutlineMeanDot"]]) {
+          argList$color <- "white"
+        }
 
-      argList <- list(
-        dodge_width = tab[["dodgeMeanDot"]],
-        alpha       = tab[["alphaMeanDot"]],
-        size        = tab[["sizeMeanDot"]],
-        shape       = 21
-      )
-
-      if (tab[["blackOutlineMeanDot"]]) {
-        argList$color <- "black"
+        do.call(tidyplots::add_mean_dot, c(list(p), argList))
       }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_mean_dot,
-        c(list(tidyplot_obj), argList)
-      )
     }
 
     # Add Median Dot (tidyplots::add_median_dot)----
     if (tab[["addMedianDot"]]) {
-
-      argList <- list(
-        dodge_width = tab[["dodgeMedianDot"]],
-        size        = tab[["sizeMedianDot"]],
-        alpha       = tab[["alphaMedianDot"]],
-        shape       = 21
-      )
-
-      if (tab[["blackOutlineMedianDot"]]) {
-        argList$color <- "black"
+      layer_calls$median_dot <- function(p) {
+        argList <- list(
+          dodge_width = tab[["dodgeMedianDot"]],
+          size        = tab[["sizeMedianDot"]],
+          alpha       = tab[["alphaMedianDot"]],
+          shape       = 21
+        )
+        if (tab[["blackOutlineMedianDot"]]) {
+          argList$color <- "black"
+        }
+        if (tab[["whiteOutlineMedianDot"]]) {
+          argList$color <- "white"
+        }
+        do.call(tidyplots::add_median_dot, c(list(p), argList))
       }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_median_dot,
-        c(list(tidyplot_obj), argList)
-      )
     }
 
     # Add curve fit (tidyplots::add_curve_fit)----
     if (tab[["addCurveFitPlotBuilder"]]) {
+      layer_calls$curve_fit <- function(p) {
+        argList <- list(
+          method     = tab[["curvaFitMethod"]],
+          linewidth  = tab[["linewidthCurveFit"]],
+          alpha      = tab[["transparencyCurveFit"]],
+          se         = tab[["seCurveFit"]]
+        )
 
-      argList <- list(
-        method     = tab[["curvaFitMethod"]],
-        linewidth  = tab[["linewidthCurveFit"]],
-        alpha      = tab[["transparencyCurveFit"]],
-        se         = tab[["seCurveFit"]]
-      )
+        if (tab[["blackOutlineCurveFit"]]) {
+          argList$color <- "black"
+          argList$fill  <- "black"
+        }
 
-      if (tab[["blackOutlineCurveFit"]]) {
-        argList$color <- "black"
-        argList$fill  <- "black"
+        if (colorBy %in% c("x", "y")) {
+          argList$group <- 1
+        }
+
+        do.call(tidyplots::add_curve_fit, c(list(p), argList))
       }
-
-      # If the color is based on the X or Y variable,
-      # force a single group (group = 1) so that the curve fit is applied
-      # to the entire dataset instead of separately for each color.
-      if (colorBy %in% c("x", "y")) {
-        argList$group <- 1
-      }
-
-      tidyplot_obj <- do.call(
-        tidyplots::add_curve_fit,
-        c(list(tidyplot_obj), argList)
-      )
     }
 
     # Add reference line (tidyplots::add_reference_lines)----
     if (tab[["addReferenceLinePlotBuilder"]]) {
-      tidyplot_obj <- tidyplot_obj |>
-        tidyplots::add_reference_lines(
-          y         = eval(parse(text = paste0("c(", tab[["yReferenceLine"]], ")"))),
-          x         = eval(parse(text = paste0("c(", tab[["xReferenceLine"]], ")"))),
-          linetype  = "dashed",
-          linewidth = tab[["linewidhtReferenceLines"]],
-          color     = eval(parse(text = paste0("\"", tab[["colorReferenceLine"]], "\"")))
+      layer_calls$reference_lines <- function(p) {
+        do.call(
+          tidyplots::add_reference_lines,
+          list(
+            p,
+            y         = eval(parse(text = paste0("c(", tab[["yReferenceLine"]], ")"))),
+            x         = eval(parse(text = paste0("c(", tab[["xReferenceLine"]], ")"))),
+            linetype  = "dashed",
+            linewidth = tab[["linewidhtReferenceLines"]],
+            color     = eval(parse(text = paste0("\"", tab[["colorReferenceLine"]], "\"")))
+          )
         )
+      }
     }
 
     # Add identity line ----
     if (!is.null(tab[["addIdentityLinePlotBuilder"]]) && tab[["addIdentityLinePlotBuilder"]]) {
-      if (!is.null(xVar) && xVar %in% colnames(localData) && is.numeric(localData[[xVar]])) {
-        x_min <- min(localData[[xVar]], na.rm = TRUE)
-        x_max <- max(localData[[xVar]], na.rm = TRUE)
-      } else {
-        x_min <- 0
-        x_max <- 1
-      }
+      layer_calls$identity_line <- function(p) {
+        if (!is.null(xVar) && xVar %in% colnames(localData) && is.numeric(localData[[xVar]])) {
+          x_min <- min(localData[[xVar]], na.rm = TRUE)
+          x_max <- max(localData[[xVar]], na.rm = TRUE)
+        } else {
+          x_min <- 0
+          x_max <- 1
+        }
 
-      if (!is.null(yVar) && yVar %in% colnames(localData) && is.numeric(localData[[yVar]])) {
-        y_min <- min(localData[[yVar]], na.rm = TRUE)
-        y_max <- max(localData[[yVar]], na.rm = TRUE)
-      } else {
-        y_min <- 0
-        y_max <- 1
-      }
+        if (!is.null(yVar) && yVar %in% colnames(localData) && is.numeric(localData[[yVar]])) {
+          y_min <- min(localData[[yVar]], na.rm = TRUE)
+          y_max <- max(localData[[yVar]], na.rm = TRUE)
+        } else {
+          y_min <- 0
+          y_max <- 1
+        }
 
-      if (!is.null(tab[["reversedirectionIdentityLine"]]) && tab[["reversedirectionIdentityLine"]]) {
-        tidyplot_obj <- tidyplot_obj |>
+        if (!is.null(tab[["reversedirectionIdentityLine"]]) && tab[["reversedirectionIdentityLine"]]) {
           tidyplots::add_annotation_line(
+            p     = p,
             x     = x_min,
             xend  = x_max,
             y     = y_max,
             yend  = y_min,
             color = eval(parse(text = paste0("\"", tab[["colorIdentityLine"]], "\"")))
           )
-      } else {
-        tidyplot_obj <- tidyplot_obj |>
+        } else {
           tidyplots::add_annotation_line(
+            p     = p,
             x     = x_min,
             xend  = x_max,
             y     = y_min,
             yend  = y_max,
             color = eval(parse(text = paste0("\"", tab[["colorIdentityLine"]], "\"")))
           )
+        }
       }
+    }
+
+    # Connect points with lines if needed (for RM) ----
+    if (tab[["connectRMPlotBuilder"]]) {
+      layer_calls$rm_lines <- function(p) {
+        if (is.null(jittered_point_data)) {
+          warning("Could not draw jittered RM lines, pre-calculation failed.")
+          return(p)
+        }
+
+        points_data <- jittered_point_data
+
+        if ("ID" %in% names(localData) && nrow(points_data) == nrow(localData)) {
+          points_data$ID <- localData$ID
+        } else {
+          warning("Could not connect repeated measures: ID column is missing or data length mismatch.")
+          return(p)
+        }
+
+        hasColorVar <- !is.null(colorVar) && nzchar(colorVar)
+        if (hasColorVar) {
+          points_data[[colorVar]] <- localData[[colorVar]]
+        }
+
+        lines_data <- points_data |> dplyr::arrange(ID, x)
+
+        line_mapping <- if (hasColorVar) {
+          ggplot2::aes(x = x, y = y, group = ID, color = .data[[colorVar]])
+        } else {
+          ggplot2::aes(x = x, y = y, group = ID)
+        }
+
+        p + ggplot2::geom_line(
+          data        = lines_data,
+          mapping     = line_mapping,
+          inherit.aes = FALSE,
+          alpha       = tab[["lineRMtransparency"]],
+          linewidth   = tab[["lineRMsize"]]
+        )
+      }
+    }
+
+    # Add stat ellipse ----
+    if(tab[["addStatEllipse"]]) {
+      layer_calls$stat_ellipse <- function(p) {
+        p + ggplot2::stat_ellipse(
+          geom    = "polygon",
+          alpha   = tab[["fillEllipse"]],
+          type    = tab[["ellipseType"]],
+          level   = tab[["levelEllipse"]]
+        )
+      }
+    }
+
+    # Add data label ----
+    lblVar      <- encodeColNames(tab[["labelVariablePlotBuilder"]])
+    hasLabelVar <- !is.null(lblVar) && nzchar(lblVar) && lblVar %in% names(localData)
+
+    jittered_point_data_lbl <- NULL
+    if (hasLabelVar) {
+      tmp_plot_lbl   <- .create_point_layer_func(tab)(tidyplot_obj)
+      built_lbl      <- ggplot2::ggplot_build(tmp_plot_lbl[[1]])
+      jittered_point_data_lbl <- built_lbl$data[[1]]
+    }
+
+
+    if (hasLabelVar) {
+      layer_calls$point_labels <- function(p) {
+
+        idx <- !is.na(localData[[lblVar]]) & localData[[lblVar]] != ""
+        if (!any(idx) || is.null(jittered_point_data_lbl))
+          return(p)
+
+        label_df           <- jittered_point_data_lbl[idx, ]
+        label_df$label_val <- localData[[lblVar]][idx]
+
+        hasColor <- !is.null(colorVar) && nzchar(colorVar) && colorVar %in% names(localData)
+        if (hasColor)
+          label_df[[colorVar]] <- localData[[colorVar]][idx]
+
+        aes_map <- ggplot2::aes(x = x, y = y, label = label_val)
+        if (hasColor)
+          aes_map$colour <- rlang::sym(colorVar)
+
+        p + ggrepel::geom_label_repel(
+          data         = label_df,
+          mapping      = aes_map,
+          size         = tab[["fontsizeDataLabels"]],
+          fill         = if (isTRUE(tab[["backgroundDataLabels"]]))
+            scales::alpha("white", 0.6) else NA,
+          label.size   = if (isTRUE(tab[["backgroundDataLabels"]])) .25 else 0,
+          segment.size = 0.2,
+          box.padding  = 0.2,
+          max.overlaps = Inf,
+          show.legend  = FALSE,
+          inherit.aes  = FALSE
+        )
+      }
+    }
+
+
+
+    # LAYER ORDERING ----
+    order_raw <- tab[["layerOrder"]]
+    if (!is.null(order_raw) && nzchar(trimws(order_raw))) {
+      desired_order <- trimws(strsplit(order_raw, ",")[[1]])
+      ordered_layers <- c(
+        desired_order[desired_order %in% names(layer_calls)],
+        setdiff(names(layer_calls), desired_order)
+      )
+    } else {
+      ordered_layers <- names(layer_calls)
+    }
+
+    for (lay in (ordered_layers)) {
+      tidyplot_obj <- layer_calls[[lay]](tidyplot_obj)
     }
 
     if (length(tab[["titlePlotBuilder"]]) > 0) {
@@ -1315,6 +1480,7 @@ addDecodedLabels <- function(p) {
         tidyplots::add_title(title = tab[["titlePlotBuilder"]])
     }
 
+    # Add caption ----
     if (!is.null(tab[["captionPlotBuilder"]]) && tab[["captionPlotBuilder"]] != "") {
       tidyplot_obj <- tidyplot_obj |>
         tidyplots::add_caption(caption = tab[["captionPlotBuilder"]])
@@ -1325,6 +1491,73 @@ addDecodedLabels <- function(p) {
       colorOption <- tab[["colorsAll"]]
 
 
+      # Set point size ----
+      if (!is.null(sizeVar) && sizeVar %in% colnames(localData)) {
+
+        gg <- tidyplot_obj
+
+        for (i in seq_along(gg$layers)) {
+          if (inherits(gg$layers[[i]]$geom, "GeomPoint")) {
+            gg$layers[[i]]$aes_params$size <- NULL
+            gg$layers[[i]]$mapping$size    <- rlang::sym(sizeVar)
+          }
+        }
+
+        baseSize   <- as.numeric(tab[["pointsizePlotBuilder"]]); if (is.na(baseSize)) baseSize <- 1
+        size_range <- c(tab[["pointSizeMin"]], tab[["pointSizeMax"]])
+
+        if (is.numeric(localData[[sizeVar]])) {
+
+          gg <- gg + ggplot2::scale_size_continuous(
+            name  = decodeColNames(sizeVar),
+            range = size_range
+          )
+
+        } else {
+          gg <- gg + ggplot2::scale_size_ordinal(
+            name  = decodeColNames(sizeVar),
+            range = size_range
+          )
+        }
+
+        gg <- gg + ggplot2::guides(
+          size = ggplot2::guide_legend(
+            override.aes = list(shape = 19, fill = "grey70")
+          )
+        )
+
+        tidyplot_obj <- gg
+      }
+
+     #Point shape by variable ----
+      if (!is.null(shapeVar) && shapeVar %in% colnames(localData)) {
+
+        if (length(unique(localData[[shapeVar]])) > 1) {
+
+          gg <- tidyplot_obj
+
+          for (i in seq_along(gg$layers)) {
+            if (inherits(gg$layers[[i]]$geom, "GeomPoint")) {
+              gg$layers[[i]]$aes_params$shape <- NULL
+              gg$layers[[i]]$mapping$shape <- rlang::sym(shapeVar)
+            }
+          }
+
+          gg <- gg + ggplot2::scale_shape_discrete(
+            name = decodeColNames(shapeVar)
+          )
+
+          gg <- gg + ggplot2::guides(
+            shape = ggplot2::guide_legend(
+              override.aes = list(fill = "grey70")
+            )
+          )
+
+          tidyplot_obj <- gg
+        }
+      }
+
+      # Color settings ----
       if (is.null(tab[["customColors"]]) || nchar(trimws(tab[["customColors"]])) == 0) {
         # define tidy plot palette
         tidy_colors <- list(
@@ -1355,8 +1588,8 @@ addDecodedLabels <- function(p) {
 
         # define jasp palette
         jasp_colors <- c("blue", "colorblind", "colorblind2",
-          "colorblind3", "sportsTeamsNBA", "ggplot2",
-          "grandBudapest", "jaspPalette", "gray")
+                         "colorblind3", "sportsTeamsNBA", "ggplot2",
+                         "grandBudapest", "jaspPalette", "gray")
 
         # if tidy plot palette
         if (colorOption %in% names(tidy_colors)) {
@@ -1416,6 +1649,34 @@ addDecodedLabels <- function(p) {
         ))
     }
 
+    size_range <- c(tab[["pointSizeMin"]], tab[["pointSizeMax"]])
+    mid_size <- mean(size_range)
+
+    if (!is.null(sizeVar) && sizeVar %in% colnames(localData)) {
+      guides_list <- list()
+
+      if (!is.null(colorVar) && colorVar %in% colnames(localData)) {
+        guides_list$fill <- ggplot2::guide_legend(
+          override.aes = list(size = mid_size)
+        )
+      }
+
+      if (!is.null(shapeVar) && shapeVar %in% colnames(localData)) {
+        guides_list$shape <- ggplot2::guide_legend(
+          override.aes = list(size = mid_size)
+        )
+      }
+
+      if (length(guides_list) > 0) {
+        tidyplot_obj <- tidyplot_obj |>
+          tidyplots::add(
+            do.call(ggplot2::guides, guides_list)
+          )
+      }
+    }
+
+
+
     # Read style choice
     plotStyle    <- tab[["plotStyle"]]
     baseFontSize <- tab[["baseFontSize"]]
@@ -1437,8 +1698,8 @@ addDecodedLabels <- function(p) {
     byValueX   <- tab[["breakByX"]]
 
     if (!is.null(fromValueX) && fromValueX != "" &&
-      !is.null(toValueX) && toValueX != "" &&
-      !is.null(byValueX) && byValueX != "") {
+        !is.null(toValueX) && toValueX != "" &&
+        !is.null(byValueX) && byValueX != "") {
 
       fromNumeric <- suppressWarnings(as.numeric(fromValueX))
       toNumeric   <- suppressWarnings(as.numeric(toValueX))
@@ -1453,7 +1714,7 @@ addDecodedLabels <- function(p) {
     limitToX   <- tab[["limitToX"]]
 
     if (!is.null(limitFromX) && limitFromX != "" &&
-      !is.null(limitToX)   && limitToX   != "") {
+        !is.null(limitToX)   && limitToX   != "") {
 
       limitFromNumericX <- suppressWarnings(as.numeric(limitFromX))
       limitToNumericX   <- suppressWarnings(as.numeric(limitToX))
@@ -1470,8 +1731,9 @@ addDecodedLabels <- function(p) {
     adjust_args_xaxis$cut_short_scale <- isTRUE(cutShortScale)
 
     # add padding
-    adjust_args_xaxis$padding <- c(0.1, 0.1)
-
+    XPaddingFirst <- tab[["XPaddingFirst"]]
+    XPaddingSecond <- tab[["XPaddingSecond"]]
+    adjust_args_xaxis$padding <- c(XPaddingFirst,XPaddingSecond)
     if (length(adjust_args_xaxis) > 0) {
       tidyplot_obj <- do.call(
         tidyplots::adjust_x_axis,
@@ -1517,75 +1779,95 @@ addDecodedLabels <- function(p) {
     }
 
     # Adjust Y axis (tidyplots::adjust_y_axis)----
-    adjust_args_yaxis <- list()
+    {
+      adjust_args_yaxis <- list()
 
-    titleValueY <- tab[["titleYPlotBuilder"]]
-    if (!is.null(titleValueY) && titleValueY != "") {
-      adjust_args_yaxis$title <- titleValueY
-    }
-
-    fromValueY <- tab[["breakFromY"]]
-    toValueY   <- tab[["breakToY"]]
-    byValueY   <- tab[["breakByY"]]
-
-    if (!is.null(fromValueY) && fromValueY != "" &&
-      !is.null(toValueY)   && toValueY   != "" &&
-      !is.null(byValueY)   && byValueY   != "") {
-
-      fromNumericY <- suppressWarnings(as.numeric(fromValueY))
-      toNumericY   <- suppressWarnings(as.numeric(toValueY))
-      byNumericY   <- suppressWarnings(as.numeric(byValueY))
-
-      if (!is.na(fromNumericY) && !is.na(toNumericY) && !is.na(byNumericY)) {
-        adjust_args_yaxis$breaks <- seq(fromNumericY, toNumericY, byNumericY)
+      titleValueY <- tab[["titleYPlotBuilder"]]
+      if (!is.null(titleValueY) && titleValueY != "") {
+        adjust_args_yaxis$title <- titleValueY
       }
-    }
 
-    limitFromY <- tab[["limitFromY"]]
-    limitToY   <- tab[["limitToY"]]
 
-    if (!is.null(limitFromY) && limitFromY != "" &&
-      !is.null(limitToY)   && limitToY   != "") {
+      limitFromY <- suppressWarnings(as.numeric(tab[["limitFromY"]]))
+      limitToY   <- suppressWarnings(as.numeric(tab[["limitToY"]]))
+      fromValueY <- suppressWarnings(as.numeric(tab[["breakFromY"]]))
+      toValueY   <- suppressWarnings(as.numeric(tab[["breakToY"]]))
+      byValueY   <- suppressWarnings(as.numeric(tab[["breakByY"]]))
 
-      limitFromNumericY <- suppressWarnings(as.numeric(limitFromY))
-      limitToNumericY   <- suppressWarnings(as.numeric(limitToY))
+      user_has_limits <- !is.na(limitFromY) && !is.na(limitToY)
+      user_has_breaks <- !is.na(fromValueY) && !is.na(toValueY) && !is.na(byValueY)
 
-      if (!is.na(limitFromNumericY) && !is.na(limitToNumericY)) {
-        adjust_args_yaxis$limits <- c(limitFromNumericY, limitToNumericY)
+      max_y_annot <- -Inf
+      if (!is.null(yVar) && yVar %in% colnames(localData) && is.numeric(localData[[yVar]])) {
+        if (!is.null(tab[["pairwiseComparisons"]]) && length(tab[["pairwiseComparisons"]]) > 0 && !is.null(tab[["yPositionPValue"]])) {
+          y_pos_base <- suppressWarnings(as.numeric(tab[["yPositionPValue"]]))
+          if (is.finite(y_pos_base)) max_y_annot <- max(max_y_annot, y_pos_base, na.rm = TRUE)
+        }
+        if (!is.null(tab[["annotationLineList"]]) && length(tab[["annotationLineList"]]) > 0) {
+          for (line in tab[["annotationLineList"]]) {
+            y_val <- suppressWarnings(as.numeric(line[["yAnnotation"]]))
+            yend_val <- suppressWarnings(as.numeric(line[["yendAnnotation"]]))
+            offset_raw <- suppressWarnings(as.numeric(line[["textDistanceAnnotationLine"]]))
+            if (is.finite(y_val) && is.finite(yend_val) && is.finite(offset_raw)) {
+              y_text_pos <- ((y_val + yend_val) / 2) + offset_raw
+              max_y_annot <- max(max_y_annot, y_val, yend_val, y_text_pos, na.rm = TRUE)
+            }
+          }
+        }
+        if (!is.null(tab[["annotationPlotBuilder"]]) && length(tab[["annotationPlotBuilder"]]) > 0) {
+          for (annot in tab[["annotationPlotBuilder"]]) {
+            y_pos_annot <- suppressWarnings(as.numeric(annot$annotationY))
+            if (is.finite(y_pos_annot)) {
+              max_y_annot <- max(max_y_annot, y_pos_annot, na.rm = TRUE)
+            }
+          }
+        }
+
+        y_data_range <- range(localData[[yVar]], na.rm = TRUE)
+        if (is.finite(max_y_annot) && max_y_annot > y_data_range[2]) {
+
+          if (!user_has_limits && !user_has_breaks) {
+            adjust_args_yaxis$breaks <- pretty(y_data_range)
+            adjust_args_yaxis$limits <- c(y_data_range[1], max_y_annot * 1.05)
+          }
+        }
       }
-    }
 
-    rotateLabelsY <- tab[["rotateYLabel"]]
-    adjust_args_yaxis$rotate_labels <- isTRUE(rotateLabelsY)
+      if (is.null(adjust_args_yaxis$limits) && user_has_limits) {
+        adjust_args_yaxis$limits <- c(limitFromY, limitToY)
+      }
+      if (is.null(adjust_args_yaxis$breaks) && user_has_breaks) {
+        adjust_args_yaxis$breaks <- seq(fromValueY, toValueY, byValueY)
+      }
 
-    cutShortScaleY <- tab[["cutShortScaleY"]]
-    adjust_args_yaxis$cut_short_scale <- isTRUE(cutShortScaleY)
+      adjust_args_yaxis$rotate_labels <- isTRUE(tab[["rotateYLabel"]])
+      adjust_args_yaxis$cut_short_scale <- isTRUE(tab[["cutShortScaleY"]])
+      adjust_args_yaxis$padding <- c(tab[["YPaddingFirst"]], tab[["YPaddingSecond"]])
 
-    # add padding
-    adjust_args_yaxis$padding <- c(0.1, 0.1)
+      if (length(adjust_args_yaxis) > 0) {
+        tidyplot_obj <- do.call(
+          tidyplots::adjust_y_axis,
+          c(list(tidyplot_obj), adjust_args_yaxis)
+        )
+      }
 
-    if (length(adjust_args_yaxis) > 0) {
-      tidyplot_obj <- do.call(
-        tidyplots::adjust_y_axis,
-        c(list(tidyplot_obj), adjust_args_yaxis)
-      )
-    }
-
-    enableSortY <- tab[["enableSortY"]]
-    if (isTRUE(enableSortY)) {
-      sortOrderY <- tab[["sortYLabelsOrder"]]
-      if (!is.null(sortOrderY) && sortOrderY %in% c("Increasing", "Decreasing")) {
-        reverse_orderY <- (sortOrderY == "Decreasing")
-        aggFunY        <- tab[["aggregationFunY"]]
-        if (!is.null(aggFunY) && aggFunY %in% c("mean", "median")) {
-          tidyplot_obj <- tidyplots::sort_y_axis_labels(
-            tidyplot_obj,
-            .reverse = reverse_orderY,
-            .fun     = aggFunY
-          )
+      enableSortY <- tab[["enableSortY"]]
+      if (isTRUE(enableSortY)) {
+        sortOrderY <- tab[["sortYLabelsOrder"]]
+        if (!is.null(sortOrderY) && sortOrderY %in% c("Increasing", "Decreasing")) {
+          reverse_orderY <- (sortOrderY == "Decreasing")
+          aggFunY        <- tab[["aggregationFunY"]]
+          if (!is.null(aggFunY) && aggFunY %in% c("mean", "median")) {
+            tidyplot_obj <- tidyplots::sort_y_axis_labels(
+              tidyplot_obj,
+              .reverse = reverse_orderY,
+              .fun     = aggFunY
+            )
+          }
         }
       }
     }
+
 
     # Adjust Y axis labels (tidyplots::rename_y_axis_labels)----
     if (!is.null(tab[["yAxisLabelRenamer"]]) && length(tab[["yAxisLabelRenamer"]]) > 0) {
@@ -1606,8 +1888,18 @@ addDecodedLabels <- function(p) {
       }
     }
 
+    # #Flipt plot ----
+    # if(tab[["flipPlot"]]) {
+    #   tidyplot_obj <- tidyplot_obj |> tidyplots::flip_plot()
+    # }
+
     # Extract the ggplot object from tidyplot----
     tidyplot_obj <- tidyplot_obj[[1]]
+
+    if (isTRUE(tab[["flipPlot"]])) {
+      tidyplot_obj <- tidyplot_obj + ggplot2::coord_flip(clip = "off")
+    }
+
 
     # Add annotation (using ggplot2::geom_text) ----
     if (!is.null(tab[["annotationPlotBuilder"]]) && length(tab[["annotationPlotBuilder"]]) > 0) {
@@ -1624,7 +1916,7 @@ addDecodedLabels <- function(p) {
         fontSize <- as.numeric(rowData$annotationSize)
 
         # Read annotation text color (default is black)
-        colorText <- if (!is.null(rowData$colorAnnotationLine) && nzchar(rowData$colorAnnotationLine)) {
+        colorText <- if (!is.null(rowData$colorAnnotationLine) && nzchar(rowData$colorText)) {
           rowData$colorAnnotationLine
         } else {
           "black"
@@ -1713,9 +2005,9 @@ addDecodedLabels <- function(p) {
 
       for (line in tab[["annotationLineList"]]) {
         if (!is.null(line[["xAnnotation"]]) && nzchar(line[["xAnnotation"]]) &&
-          !is.null(line[["xendAnnotation"]]) && nzchar(line[["xendAnnotation"]]) &&
-          !is.null(line[["yAnnotation"]]) && nzchar(line[["yAnnotation"]]) &&
-          !is.null(line[["yendAnnotation"]]) && nzchar(line[["yendAnnotation"]])) {
+            !is.null(line[["xendAnnotation"]]) && nzchar(line[["xendAnnotation"]]) &&
+            !is.null(line[["yAnnotation"]]) && nzchar(line[["yAnnotation"]]) &&
+            !is.null(line[["yendAnnotation"]]) && nzchar(line[["yendAnnotation"]])) {
 
           x_val    <- eval(parse(text = paste0("c(", line[["xAnnotation"]], ")")))
           xend_val <- eval(parse(text = paste0("c(", line[["xendAnnotation"]], ")")))
@@ -1815,7 +2107,7 @@ addDecodedLabels <- function(p) {
     }
 
 
-    # Apply theme
+    # Apply theme ----
     if (plotStyle == "JASP") {
       tidyplot_obj <- tidyplot_obj +
         jaspGraphs::themeJaspRaw(fontsize = baseFontSize, legend.position = legend_position) +
@@ -1876,6 +2168,17 @@ addDecodedLabels <- function(p) {
         ggplot2::theme(legend.title = ggplot2:::element_blank())
     }
 
+    # Rotate labels ----
+
+    if (isTRUE(tab[["rotateXLabel"]])) {
+      tidyplot_obj <- tidyplot_obj +
+        ggplot2::theme(axis.text.x = ggplot2::element_text(angle = 45, hjust = 1))
+    }
+    if (isTRUE(tab[["rotateYLabel"]])) {
+      tidyplot_obj <- tidyplot_obj +
+        ggplot2::theme(axis.text.y = ggplot2::element_text(angle = 45, hjust = 1))
+    }
+
     # Facet logic for row / column ----------
 
     hasRows <- (!is.null(rowsVar) && rowsVar != "")
@@ -1896,9 +2199,9 @@ addDecodedLabels <- function(p) {
       tidyplot_obj <- tidyplot_obj +
         ggplot2::scale_y_continuous(
           sec.axis = ggplot2::sec_axis(~.,
-            name   = axis_name,
-            breaks = NULL,
-            labels = NULL
+                                       name   = axis_name,
+                                       breaks = NULL,
+                                       labels = NULL
           )
         )
     }
@@ -1980,31 +2283,7 @@ addDecodedLabels <- function(p) {
     }
 
 
-    # Connect points with lines if needed (for RM)----
-    if (tab[["connectRMPlotBuilder"]]) {
-      gg    <- tidyplot_obj
-      built <- ggplot2::ggplot_build(gg)
 
-      points_data <- built$data[[1]] |>
-        dplyr::mutate(ID = localData$ID)
-
-      lines_data <- points_data |>
-        dplyr::arrange(ID, x) |>
-        dplyr::group_by(ID) |>
-        dplyr::mutate(order = dplyr::row_number()) |>
-        dplyr::ungroup()
-
-      gg2 <- gg +
-        ggplot2::geom_line(
-          data          = lines_data,
-          ggplot2::aes(x = x, y = y, group = ID),
-          inherit.aes   = FALSE,
-          color         = lines_data$colour,
-          alpha         = tab[["lineRMtransparency"]],
-          size          = tab[["lineRMsize"]]
-        )
-      tidyplot_obj <- gg2
-    }
 
     # P value from ggpubr::stat_pvalue_manual----
 
@@ -2016,7 +2295,7 @@ addDecodedLabels <- function(p) {
       }
 
       if (!is.null(yVar) && yVar %in% colnames(localData) && !(is.numeric(localData[[yVar]]) ||
-        is.ordered(localData[[yVar]]))) {
+                                                               is.ordered(localData[[yVar]]))) {
         .quitAnalysis("The X-Axis variable can only be a factor variable.
              The Y-Axis variable must be either continuous or ordinal.")
       }
@@ -2113,6 +2392,9 @@ addDecodedLabels <- function(p) {
         )
     }
 
+
+
+
     # asPercentage axis labeling ----
     asPercentage <- isTRUE(tab[["asPercentage"]])
 
@@ -2125,8 +2407,12 @@ addDecodedLabels <- function(p) {
       tidyplot_obj <- tidyplot_obj + ggplot2::scale_x_continuous(labels = scales::percent_format(accuracy = 1))
     }
 
-    # Render plot ----------
+    if (!hasColor) {
+      tidyplot_obj <- tidyplot_obj +
+        ggplot2::guides(color = "none", fill = "none")
+    }
 
+    # Render plot -----
 
     if (identical(rmOption, "RM")) {
       tidyplot_obj <- addDecodedLabels(tidyplot_obj)
@@ -2144,7 +2430,6 @@ addDecodedLabels <- function(p) {
 .plotBuilderOutputIndividualPlots <- function(jaspResults, options, plotResults) {
   updatedPlots <- plotResults$updatedPlots
 
-  # Create or retrieve individual tidy plots container
   if (!is(jaspResults[["tidyPlotsContainer"]], "JaspContainer")) {
     tidyPlotsContainer <- createJaspContainer(title = gettext("Plots"))
     jaspResults[["tidyPlotsContainer"]] <- tidyPlotsContainer
@@ -2152,30 +2437,29 @@ addDecodedLabels <- function(p) {
     tidyPlotsContainer <- jaspResults[["tidyPlotsContainer"]]
   }
 
-  # Render individual tidy plots in their container
-  for (plotId in names(updatedPlots)) {
+  allPlotIds <- as.character(sapply(options$PlotBuilderTab, `[[`, "value"))
 
+  for (plotId in allPlotIds) {
+
+    tab     <- options$PlotBuilderTab[[match(plotId, allPlotIds)]]
     plotKey <- paste0("tidyPlot_", plotId)
-    if (!is(tidyPlotsContainer[[plotKey]], "JaspPlot")) {
-      # Retrieve plot dimensions from the corresponding tab
-      tab <- NULL
-      for (t in options$PlotBuilderTab) {
-        if (as.character(t$value) == plotId) {
-          tab <- t
-          break
-        }
-      }
 
+    if (!is(tidyPlotsContainer[[plotKey]], "JaspPlot")) {
       tidyPlot <- createJaspPlot(
-        title  = paste(plotId),
+        title  = plotId,
         width  = tab[["widthPlotBuilder"]],
         height = tab[["heightPlotBuilder"]]
       )
-      tidyPlot$plotObject <- updatedPlots[[plotId]]
       tidyPlot$dependOn(names(options))
       tidyPlotsContainer[[plotKey]] <- tidyPlot
     } else {
-      tidyPlotsContainer[[plotKey]]$plotObject <- updatedPlots[[plotId]]
+      tidyPlot <- tidyPlotsContainer[[plotKey]]
+    }
+
+    if (!is.null(updatedPlots[[plotId]])) {
+      tidyPlot$plotObject <- updatedPlots[[plotId]]
+    } else {
+      tidyPlot$plotObject <- ggplot2::ggplot() + ggplot2::theme_void()
     }
   }
 }

--- a/R/jaspPlotBuilder.R
+++ b/R/jaspPlotBuilder.R
@@ -106,7 +106,7 @@ jaspPlotBuilderInternal <- function(jaspResults, dataset, options) {
 
       missing.vars <- setdiff(rm.vars, colnames(ds_rm))
       if (length(missing.vars) > 0)
-        .quitAnalysis("Please assign a variable to every RM factor (defined in Repeated Measures Factors) within Repeated Measures Cells.")
+        .quitAnalysis(gettext("Please assign a variable to every RM factor (defined in Repeated Measures Factors) within Repeated Measures Cells."))
 
       ds_rm <- .shortToLong(
         ds_rm,

--- a/inst/qml/jaspPlotBuilder.qml
+++ b/inst/qml/jaspPlotBuilder.qml
@@ -1,4 +1,4 @@
-	//
+//
 // Copyright (C) 2013-2024 University of Amsterdam
 //
 // This program is free software: you can redistribute it and/or modify
@@ -24,318 +24,742 @@ import JASP.Controls
 
 
 Form {
-	columns: 1
+columns: 1
 
-	info: qsTr("The <b>Plot Builder (beta)</b> lets you assemble a complete figure in just a few clicks.<br/><br/>"
-			+ "1. <b>Decide on design:</b> At the very top choose <i>Repeated measurements → Yes</i> if the same subjects are measured more than once "
-			+ "(e.g., across time-points or conditions); otherwise leave <i>No</i> selected. "
-			+ "2. <b>Map your variables:</b> Drag variables from the list on the left into the fields on the right (X-Axis, Y-Axis, etc). "
-			+ "3. <b>Choose what to display:</b> Expand the <i>Data and geometries</i> accordion to add layers such as raw points, histograms/box-/violin plots, "
-			+ "counts, proportions, Mean or Median summaries, etc. "
-			+ "4. <b>Polish the figure:</b> Use the remaining accordions to fine-tune axes, titles, annotations, themes, colors, sizing, and legend placement.")
+info: qsTr("The <b>Plot Builder (beta)</b> lets you assemble a complete figure in just a few clicks.<br/><br/>"
+		+ "<ol><li><b>Decide on design:</b> At the very top choose <i>Repeated measurements → Yes</i> if the same subjects are measured more than once "
+		+ "(e.g., across time-points or conditions); otherwise leave <i>No</i> selected. </li>"
+		+ "<li><b>Map your variables:</b> Drag variables from the list on the left into the fields on the right (X-Axis, Y-Axis, etc). </li>"
+		+ "<li><b>Choose what to display:</b> Expand the <i>Data and geometries</i> accordion to add layers such as raw points, histograms/box-/violin plots, "
+		+ "counts, proportions, Mean or Median summaries, etc.</li>"
+		+ "<li><b>Polish the figure:</b> Use the remaining accordions to fine-tune axes, titles, annotations, themes, colors, sizing, and legend placement.</li>")
 
 
 
-	infoBottom:
-		"## " + qsTr("References") + "\n" +
-		"- Engler, J. B. (2025). “Tidyplots Empowers Life Scientists With Easy Code-Based Data Visualization.” _iMeta_, 4, e70018. https://doi.org/10.1002/imt2.70018\n" +
-		"- Engler, J. B. (2024). _tidyplots: Tidy Plots for Scientific Papers_. R package version 0.2.1. Available at: <https://CRAN.R-project.org/package=tidyplots>.\n" +
-		"- Wickham, H., & Seidel, D. (2023). _rlang: Functions for Base Types and Core R and 'Tidyverse' Features_. R package version 1.1.1. Available at: <https://CRAN.R-project.org/package=rlang>.\n" +
-		"- Wickham, H., François, R., Henry, L., Müller, K., & Vaughan, D. (2023). _dplyr: A Grammar of Data Manipulation_. R package version 1.1.4. Available at: <https://CRAN.R-project.org/package=dplyr>.\n" +
-		"- Wickham, H., & Henry, L. (2023). _tidyr: Tidy Messy Data_. R package version 1.3.0. Available at: <https://CRAN.R-project.org/package=tidyr>.\n" +
-		"- Dawson, C. (2024). _ggprism: A 'ggplot2' Extension Inspired by 'GraphPad Prism'_. R package version 1.0.5. Available at: <https://csdaw.github.io/ggprism/>.\n" +
-		"- Pedersen, T. L. (2020). _patchwork: The Composer of Plots_. R package version 1.1.1. Available at: <https://CRAN.R-project.org/package=patchwork>.\n" +
-		"- Wickham, H., & Grolemund, G. (2017). _R for Data Science: Import, Tidy, Transform, Visualize, and Model Data_. O'Reilly Media.\n" +
-		"- Wickham, H. (2016). _ggplot2: Elegant Graphics for Data Analysis_. Springer-Verlag New York.\n" +
-		"- Kassambara, A. (2024). _ggpubr: 'ggplot2' Based Publication Ready Plots_. R package version 0.6.0. Available at: <https://rpkgs.datanovia.com/ggpubr/>.\n" +
-		"- Dunnington, D. (2023). _ggeasy: Easy Access to 'ggplot2' Commands_. R package version 0.1.4. Available at: <https://CRAN.R-project.org/package=ggeasy>.\n" +
-		"- Wickham, H., & Henry, L. (2023). _forcats: Tools for Working with Categorical Variables (Factors)_. R package version 1.0.0. Available at: <https://CRAN.R-project.org/package=forcats>.\n"
+infoBottom:
+	"## " + qsTr("References") + "\n" +
+	"- Engler, J. B. (2025). “Tidyplots Empowers Life Scientists With Easy Code-Based Data Visualization.” _iMeta_, 4, e70018. https://doi.org/10.1002/imt2.70018\n" +
+	"- Engler, J. B. (2024). _tidyplots: Tidy Plots for Scientific Papers_. R package version 0.2.1. Available at: <https://CRAN.R-project.org/package=tidyplots>.\n" +
+	"- Wickham, H., & Seidel, D. (2023). _rlang: Functions for Base Types and Core R and 'Tidyverse' Features_. R package version 1.1.1. Available at: <https://CRAN.R-project.org/package=rlang>.\n" +
+	"- Wickham, H., François, R., Henry, L., Müller, K., & Vaughan, D. (2023). _dplyr: A Grammar of Data Manipulation_. R package version 1.1.4. Available at: <https://CRAN.R-project.org/package=dplyr>.\n" +
+	"- Wickham, H., & Henry, L. (2023). _tidyr: Tidy Messy Data_. R package version 1.3.0. Available at: <https://CRAN.R-project.org/package=tidyr>.\n" +
+	"- Dawson, C. (2024). _ggprism: A 'ggplot2' Extension Inspired by 'GraphPad Prism'_. R package version 1.0.5. Available at: <https://csdaw.github.io/ggprism/>.\n" +
+	"- Pedersen, T. L. (2020). _patchwork: The Composer of Plots_. R package version 1.1.1. Available at: <https://CRAN.R-project.org/package=patchwork>.\n" +
+	"- Wickham, H., & Grolemund, G. (2017). _R for Data Science: Import, Tidy, Transform, Visualize, and Model Data_. O'Reilly Media.\n" +
+	"- Wickham, H. (2016). _ggplot2: Elegant Graphics for Data Analysis_. Springer-Verlag New York.\n" +
+	"- Kassambara, A. (2024). _ggpubr: 'ggplot2' Based Publication Ready Plots_. R package version 0.6.0. Available at: <https://rpkgs.datanovia.com/ggpubr/>.\n" +
+	"- Dunnington, D. (2023). _ggeasy: Easy Access to 'ggplot2' Commands_. R package version 0.1.4. Available at: <https://CRAN.R-project.org/package=ggeasy>.\n" +
+	"- Wickham, H., & Henry, L. (2023). _forcats: Tools for Working with Categorical Variables (Factors)_. R package version 1.0.0. Available at: <https://CRAN.R-project.org/package=forcats>.\n"
 
-	TabView {
-		infoLabel: qsTr("The basic setup: decide on the design (repeated-measures or non-repeated-measures) and select the variables")
-		name: "PlotBuilderTab"
-		newItemName: qsTr("Plot 1")
-		rowComponent: Group {
+TabView {
+	infoLabel: qsTr("The basic setup: decide on the design (repeated-measures or non-repeated-measures) and select the variables")
+	name: "PlotBuilderTab"
+	newItemName: qsTr("Plot 1")
+	rowComponent: Group {
 
-			childControlsArea.anchors.leftMargin: jaspTheme.contentMargin
+		childControlsArea.anchors.leftMargin: jaspTheme.contentMargin
 
-			Group{
-				columns:3
-				RadioButtonGroup {
-					id:						isRM
-					Layout.columnSpan:		1
-					name:					"isRM"
-					title:					qsTr("Repeated measurements")
-					radioButtonsOnSameRow:	true
-					columns:				2
-					info: qsTr("Select whether you want to create a repeated-measures plot or a non-repeated-measures plot")
+		Group{
+			columns:3
+			RadioButtonGroup {
+				id:						isRM
+				Layout.columnSpan:		1
+				name:					"isRM"
+				title:					qsTr("Repeated measurements")
+				radioButtonsOnSameRow:	true
+				columns:				2
+				info: qsTr("Select whether you want to create a repeated-measures plot or a non-repeated-measures plot")
 
-					RadioButton {
-						label:		qsTr("No")
-						info: qsTr("Select this to create a non-repeated-measures plot")
-						value:		"noRM"
-						id:			noRM
-						checked:	true
-					}
-
-					RadioButton {
-						label:		qsTr("Yes")
-						info: qsTr("Select this to create a repeated-measures plot")
-						value:		"RM"
-						id:          yesRM
-					}
+				RadioButton {
+					label:		qsTr("No")
+					info: qsTr("Select this to create a non-repeated-measures plot")
+					value:		"noRM"
+					id:			noRM
+					checked:	true
 				}
 
-				CheckBox{
-				name: "deleteNAListwise"
-				id: deleteNAlistwise
-				checked: true
-				visible: yesRM.checked
-				enabled: yesRM.checked
-				info: qsTr("ON (listwise deletion): if a case is missing even one of the selected variables, the whole case is excluded."
-						   + "OFF: keep every case and ignore only the specific values that are missing")
-				label: qsTr("Delete missing values listwise")
+				RadioButton {
+					label:		qsTr("Yes")
+					info: qsTr("Select this to create a repeated-measures plot")
+					value:		"RM"
+					id:          yesRM
 				}
 			}
 
-			Group {
-				VariablesForm {
+			CheckBox{
+			name: "deleteNAListwise"
+			id: deleteNAlistwise
+			checked: true
+			visible: yesRM.checked
+			enabled: yesRM.checked
+			info: qsTr("ON (listwise deletion): if a case is missing even one of the selected variables, the whole case is excluded."
+					   + "OFF: keep every case and ignore only the specific values that are missing")
+			label: qsTr("Delete missing values listwise")
+			}
+		}
 
-					removeInvisibles:true
-					preferredWidth: jaspForm.width - 2 * jaspTheme.contentMargin
-					preferredHeight: 300 * jaspTheme.uiScale
-					visible: noRM.checked
+		Group {
+			VariablesForm {
 
-					infoLabel: qsTr("Input for non-repeated measures plot")
+				removeInvisibles:true
+				preferredWidth: jaspForm.width - 2 * jaspTheme.contentMargin
+				preferredHeight: 300 * jaspTheme.uiScale
+				visible: noRM.checked
 
-					// NO RM DATASET -------------------------------------------------------------------------------------------------------------------------
+				infoLabel: qsTr("Input for non-repeated measures plot")
 
-					AvailableVariablesList {
-						name: "allVariablesList"
-					}
+				// NO RM DATASET -------------------------------------------------------------------------------------------------------------------------
 
-					AssignedVariablesList {
-						name: "variableXPlotBuilder"
-						title: qsTr("X-Axis Variable")
-						id: variableXPlotBuilder
-						allowedColumns: ["scale", "ordinal", "nominal"]
-						minLevels: 2
-						singleVariable: true
-						info: qsTr("Select the variable for the X-Axis")
-					}
+				AvailableVariablesList {
+					name: "allVariablesList"
+				}
 
-					AssignedVariablesList {
-						name: "variableYPlotBuilder"
-						title: qsTr("Y-Axis Variable")
-						allowedColumns: ["scale", "ordinal", "nominal"]
-						id: variableYPlotBuilder
-						singleVariable: true
-						info: qsTr("Select the variable for the Y-Axis")
-					}
+				AssignedVariablesList {
+					name: "variableXPlotBuilder"
+					title: qsTr("X-Axis Variable")
+					id: variableXPlotBuilder
+					allowedColumns: ["scale", "ordinal", "nominal"]
+					minLevels: 2
+					singleVariable: true
+					info: qsTr("Select the variable for the X-Axis")
+				}
 
-					AssignedVariablesList {
-						name: "variableColorPlotBuilder"
-						title: qsTr("Group Variable")
-						id: variableColorPlotBuilder
-						allowedColumns: ["scale", "ordinal", "nominal"]
-						minLevels: 2
-						visible: !yesRM.checked
-						singleVariable: true
-						info: qsTr("Select the variable for data grouping, which will also determine the coloring.")
-						onCountChanged: {
-							if (count > 0) {
-								colorByVariableX.checked = false;
-								colorByVariableY.checked = false;
-							}
+				AssignedVariablesList {
+					name: "variableYPlotBuilder"
+					title: qsTr("Y-Axis Variable")
+					allowedColumns: ["scale", "ordinal", "nominal"]
+					id: variableYPlotBuilder
+					singleVariable: true
+					info: qsTr("Select the variable for the Y-Axis")
+				}
+
+				AssignedVariablesList {
+					name: "variableColorPlotBuilder"
+					title: qsTr("Group Variable")
+					id: variableColorPlotBuilder
+					allowedColumns: ["scale", "ordinal", "nominal"]
+					minLevels: 2
+					visible: !yesRM.checked
+					singleVariable: true
+					info: qsTr("Select the variable for data grouping, which will also determine the coloring.")
+					onCountChanged: {
+						if (count > 0) {
+							colorByVariableX.checked = false;
+							colorByVariableY.checked = false;
 						}
-					}
-
-					AssignedVariablesList {
-						name: "columnsvariableSplitPlotBuilder"
-						title: qsTr("Split (Columns)")
-						id: columnsvariableSplitPlotBuilder
-						allowedColumns: ["ordinal", "nominal"]
-						singleVariable: true
-						info: qsTr("You can choose a variable to split the plots into columns")
-					}
-
-					AssignedVariablesList {
-						name: "rowsvariableSplitPlotBuilder"
-						title: qsTr("Split (Rows)")
-						id: rowsvariableSplitPlotBuilder
-						allowedColumns: ["ordinal", "nominal"]
-						singleVariable: true
-						info: qsTr("You can choose a variable to split the plots into rows")
-
-					}
-
-					AssignedVariablesList {
-						name: "gridVariablePlotBuilder"
-						title: qsTr("Grid")
-						id: gridVariablePlotBuilder
-						allowedColumns: ["ordinal", "nominal"]
-						singleVariable: true
-						info: qsTr("You can choose a variable to make a grid")
 					}
 				}
 
-				//  RM DATASET ---------------------------------------------------------------------------------------------------------------------------
+				AssignedVariablesList {
+					name: "columnsvariableSplitPlotBuilder"
+					title: qsTr("Split (Columns)")
+					id: columnsvariableSplitPlotBuilder
+					allowedColumns: ["ordinal", "nominal"]
+					singleVariable: true
+					info: qsTr("You can choose a variable to split the plots into columns")
+				}
 
-				VariablesForm {
-
-					removeInvisibles:	true
-					preferredWidth: jaspForm.width - 2 * jaspTheme.contentMargin
-					preferredHeight: 600  * jaspTheme.uiScale
-					visible: yesRM.checked
-
-					infoLabel: qsTr("Input for repeated measures plot")
-
-					AvailableVariablesList {
-						name: "allVariablesListRM"
-					}
-
-
-					FactorLevelList	{
-						name: "repeatedMeasuresFactors";
-						id: repeatedMeasuresFactors
-						title: qsTr("Repeated Measures Factors")
-						info:qsTr("Here you can specify the factor for the repeated measures. For example, it could be time (e.g., 24 h, 48 h, 72 h) or conditions like before and after")
-						height: 180 * preferencesModel.uiScale;	factorName: qsTr("RM Factor")
-
-					}
-
-					AssignedRepeatedMeasuresCells {
-						id: rmCells
-						name: "repeatedMeasuresCells"
-						info: qsTr("Assign the variables that correspond to each level of the repeated measures factor. For example, if the factor is time, assign variables like '24h', '48h', and '72h'")
-						title: qsTr("Repeated Measures Cells")
-						source: "repeatedMeasuresFactors"
-					}
-
-					AssignedVariablesList {
-						name: "betweenSubjectFactors"
-						title: qsTr("Between Subject Factors")
-						info: qsTr("Select the between-subject factors that distinguish different groups of subjects, such as treatment group, gender, or genotype. These variables must be categorical (nominal) with at least two levels")
-						allowedColumns: ["nominal"]
-						minLevels: 2
-					}
-
-					AssignedVariablesList {
-						name: "covariates"
-						title: qsTr("Covariates")
-						info: qsTr("Select continuous variables that may influence the outcome and should be included as covariates in the analysis")
-						allowedColumns: ["scale"]
-						minNumericLevels: 2
-					}
-
+				AssignedVariablesList {
+					name: "rowsvariableSplitPlotBuilder"
+					title: qsTr("Split (Rows)")
+					id: rowsvariableSplitPlotBuilder
+					allowedColumns: ["ordinal", "nominal"]
+					singleVariable: true
+					info: qsTr("You can choose a variable to split the plots into rows")
 
 				}
 
-			} //
-
-			/* -------------------------------------------------------------------
-			   Point annotations – repelled data-labels
-			   ------------------------------------------------------------------- */
-
-
-			Section{
-				// infoLabel: qsTr("Here you can define the role of the repeated measures variables in the plot.")
-				visible: yesRM.checked
-				title: qsTr("Assign repeated measures components")
-				VariablesForm {
-					removeInvisibles: true
-					id: varsForm
-					preferredHeight: 300 * preferencesModel.uiScale
-
-					AvailableVariablesList {
-						id: withinComponents
-						name: "withinComponents"
-						title: qsTr("Repeated Measures Components")
-						source: ["repeatedMeasuresFactors", "betweenSubjectFactors", "covariates"]
-						enabled: yesRM.checked
-						onEnabledChanged: {
-							if (enabled) {
-								while (count > 0) {
-									itemDoubleClicked(0)
-								}
-							}
-						}
-					}
-
-					AssignedVariablesList {
-						id: xVarRM
-						allowedColumns: ["scale", "ordinal", "nominal"]
-						name: "xVarRM"
-						info: qsTr("Select the variable for the X-Axis")
-						title: qsTr("X-Axis Variable")
-						singleVariable: true
-					}
-
-					AssignedVariablesList {
-						id: groupVarRM
-						name: "groupVarRM"
-						title: qsTr("Group Variable")
-						singleVariable: true
-						info: qsTr("Select the variable for data grouping, which will also determine the coloring")
-						allowedColumns: ["scale", "ordinal", "nominal"]
-					}
-
-					AssignedVariablesList {
-						name: "colSplitRM"
-						title: qsTr("Split (Columns)")
-						id: colSplitRM
-						allowedColumns: ["ordinal", "nominal"]
-						info: qsTr("You can choose a variable to split the plots into columns")
-						singleVariable: true
-					}
-
-					AssignedVariablesList {
-						name: "rowSplitRM"
-						title: qsTr("Split (Rows)")
-						id: rowSplitRM
-						allowedColumns: ["ordinal", "nominal"]
-						singleVariable: true
-						info: qsTr("You can choose a variable to split the plots into rows")
-					}
-
-					AssignedVariablesList {
-						name: "gridVarRM"
-						title: qsTr("Grid")
-						id: gridVarRM
-						allowedColumns: ["ordinal", "nominal"]
-						singleVariable: true
-						info: qsTr("You can choose a variable to make a grid")
-					}
+				AssignedVariablesList {
+					name: "gridVariablePlotBuilder"
+					title: qsTr("Grid")
+					id: gridVariablePlotBuilder
+					allowedColumns: ["ordinal", "nominal"]
+					singleVariable: true
+					info: qsTr("You can choose a variable to make a grid")
 				}
 			}
+
+			//  RM DATASET ---------------------------------------------------------------------------------------------------------------------------
+
+			VariablesForm {
+
+				removeInvisibles:	true
+				preferredWidth: jaspForm.width - 2 * jaspTheme.contentMargin
+				preferredHeight: 600  * jaspTheme.uiScale
+				visible: yesRM.checked
+
+				infoLabel: qsTr("Input for repeated measures plot")
+
+				AvailableVariablesList {
+					name: "allVariablesListRM"
+				}
+
+
+				FactorLevelList	{
+					name: "repeatedMeasuresFactors";
+					id: repeatedMeasuresFactors
+					title: qsTr("Repeated Measures Factors")
+					info:qsTr("Here you can specify the factor for the repeated measures. For example, it could be time (e.g., 24 h, 48 h, 72 h) or conditions like before and after")
+					height: 180 * preferencesModel.uiScale;	factorName: qsTr("RM Factor")
+
+				}
+
+				AssignedRepeatedMeasuresCells {
+					id: rmCells
+					name: "repeatedMeasuresCells"
+					info: qsTr("Assign the variables that correspond to each level of the repeated measures factor. For example, if the factor is time, assign variables like '24h', '48h', and '72h'")
+					title: qsTr("Repeated Measures Cells")
+					source: "repeatedMeasuresFactors"
+				}
+
+				AssignedVariablesList {
+					name: "betweenSubjectFactors"
+					title: qsTr("Between Subject Factors")
+					info: qsTr("Select the between-subject factors that distinguish different groups of subjects, such as treatment group, gender, or genotype. These variables must be categorical (nominal) with at least two levels")
+					allowedColumns: ["nominal"]
+					minLevels: 2
+				}
+
+				AssignedVariablesList {
+					name: "covariates"
+					title: qsTr("Covariates")
+					info: qsTr("Select continuous variables that may influence the outcome and should be included as covariates in the analysis")
+					allowedColumns: ["scale"]
+					minNumericLevels: 2
+				}
+
+
+			}
+
+		} //
+
+		/* -------------------------------------------------------------------
+		   Point annotations – repelled data-labels
+		   ------------------------------------------------------------------- */
+
+
+		Section{
+			// infoLabel: qsTr("Here you can define the role of the repeated measures variables in the plot.")
+			visible: yesRM.checked
+			title: qsTr("Assign repeated measures components")
+			VariablesForm {
+				removeInvisibles: true
+				id: varsForm
+				preferredHeight: 300 * preferencesModel.uiScale
+
+				AvailableVariablesList {
+					id: withinComponents
+					name: "withinComponents"
+					title: qsTr("Repeated Measures Components")
+					source: ["repeatedMeasuresFactors", "betweenSubjectFactors", "covariates"]
+					enabled: yesRM.checked
+					onEnabledChanged: {
+						if (enabled && count > 0 && xVarRM.count == 0)
+							itemDoubleClicked(0)
+					}
+				}
+
+				AssignedVariablesList {
+					id: xVarRM
+					allowedColumns: ["scale", "ordinal", "nominal"]
+					name: "xVarRM"
+					info: qsTr("Select the variable for the X-Axis")
+					title: qsTr("X-Axis Variable")
+					singleVariable: true
+				}
+
+				AssignedVariablesList {
+					id: groupVarRM
+					name: "groupVarRM"
+					title: qsTr("Group Variable")
+					singleVariable: true
+					info: qsTr("Select the variable for data grouping, which will also determine the coloring")
+					allowedColumns: ["scale", "ordinal", "nominal"]
+				}
+
+				AssignedVariablesList {
+					name: "colSplitRM"
+					title: qsTr("Split (Columns)")
+					id: colSplitRM
+					allowedColumns: ["ordinal", "nominal"]
+					info: qsTr("You can choose a variable to split the plots into columns")
+					singleVariable: true
+				}
+
+				AssignedVariablesList {
+					name: "rowSplitRM"
+					title: qsTr("Split (Rows)")
+					id: rowSplitRM
+					allowedColumns: ["ordinal", "nominal"]
+					singleVariable: true
+					info: qsTr("You can choose a variable to split the plots into rows")
+				}
+
+				AssignedVariablesList {
+					name: "gridVarRM"
+					title: qsTr("Grid")
+					id: gridVarRM
+					allowedColumns: ["ordinal", "nominal"]
+					singleVariable: true
+					info: qsTr("You can choose a variable to make a grid")
+				}
+			}
+		}
+
+		Label {
+			text: qsTr("Data and geometries")
+			wrapMode: Text.Wrap
+			color: "black"
+			font.bold: true
+		}
+
+		// -------------------------------------------------------------------
+		// Data points
+		// -------------------------------------------------------------------
+
+
+	Section {
+			title: qsTr("Individual data points")
 
 			Label {
-				text: qsTr("Data and geometries")
+				text: qsTr("Required: X AND Y-Axis Variables")
 				wrapMode: Text.Wrap
 				color: "black"
-				font.bold: true
 			}
 
-			// -------------------------------------------------------------------
-			// Data points
-			// -------------------------------------------------------------------
+			CheckBox {
+				name: "addDataPoint"
+				label: qsTr("Individual data points")
+				id: addDataPoint
+				info: qsTr("Check this option to show individual data points on the plot")
+				columns: 4
+				enabled: (
+							 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
+							 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
 
+							 ||
 
-		Section {
-				title: qsTr("Individual data points")
+							 // 2. If repeated measures (yesRM) and at least one of the following is true:
+							 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
 
-				Label {
-					text: qsTr("Required: X AND Y-Axis Variables")
-					wrapMode: Text.Wrap
-					color: "black"
+								  xVarRM.count > 0
+
+								  ))
+							 )
+
+				onEnabledChanged: {
+					if (!enabled) {
+						checked = false;
+					}
 				}
 
+				Group {
+					DoubleField {
+						info: qsTr("Set the point size")
+						name: "pointsizePlotBuilder"
+						id: pointsizePlotBuilder
+						label: qsTr("Point size")
+						enabled: !sizeByVariable.checked
+						value: 3
+						min: 0
+						max: 10
+					}
+
+					CheckBox{
+					name:"sizeByVariable"
+					id: sizeByVariable
+					label: qsTr("Size by variable")
+					info: qsTr("Choose this if you want the point size to be determined by a variable rather than a fixed constant")
+					}
+
+					CheckBox{
+					name:"shapebyVariable"
+					id: shapebyVariable
+					label: qsTr("Shape by variable")
+					info: qsTr("Choose this if you want the point shape to be determined by a variable")
+					}
+				}
+
+				Group {
+					DoubleField {
+						info: "A small “jitter” is added to the individual data points displayed to prevent overlaps. Here you can adjust the height of the jitter."
+						name: "jitterhPlotBuilder"
+						id: jitterhPlotBuilder
+						label: qsTr("Jitter height")
+						value: 0.3
+						min: 0
+						max: 10
+					}
+
+					DoubleField {
+						info: "A small “jitter” is added to the individual data points displayed to prevent overlaps. Here you can adjust the width of the jitter."
+						name: "jitterwPlotBuilder"
+						id: jitterwPlotBuilder
+						label: qsTr("Jitter width")
+						value: 0.3
+						min: 0
+						max: 10
+					}
+				}
+
+				Group {
+					DoubleField {
+						name: "alphaPlotBuilder"
+						id: alphaPlotBuilder
+						label: qsTr("Transparency")
+						info: qsTr("Set the transparency")
+						value: 0.5
+						min: 0
+						max: 1
+					}
+
+					DoubleField {
+						name: "pointDodgePlotBuilder"
+						label: qsTr("Dodge")
+						info: qsTr("Adjusts the horizontal “dodge” spacing between subgroup geometric elements. "
+								  + "Only takes effect when a grouping variable is mapped (e.g., male vs. female within each species). "
+								  + "A value of 0 overlays the elements; higher values push the subgroups farther apart")
+						id: pointDodgePlotBuilder
+						defaultValue: 0.8
+					}
+				}
+
+				Group{
+					CheckBox {
+						name: "blackOutlineDataPoint"
+						label: qsTr("Black outline")
+						checked: false
+						enabled: !shapebyVariable.checked
+						info: qsTr("Add a black outline/border to the elements")
+						onEnabledChanged: {
+							if (!enabled) {
+								checked = false;
+							}
+						}
+					}
+
+					CheckBox {
+						name: "whiteBorder"
+						label: qsTr("White outline")
+						checked: false
+						enabled: !shapebyVariable.checked
+						info: qsTr("Add a white outline/border to the elements")
+						onEnabledChanged: {
+							if (!enabled) {
+								checked = false;
+							}
+						}
+					}
+
+					CheckBox {
+						name: "emptyCircles"
+						label: qsTr("Empty circles")
+						checked: false
+						enabled: !shapebyVariable.checked
+						info: qsTr("Remove the fill")
+						onEnabledChanged: {
+							if (!enabled) {
+								checked = false;
+							}
+						}
+					}
+				}
+
+			}
+
+			VariablesForm{
+				visible: sizeByVariable.checked
+				enabled: sizeByVariable.checked
+				preferredWidth: jaspForm.width - 2 * jaspTheme.contentMargin
+				preferredHeight: 100 * preferencesModel.uiScale
+
+				AvailableVariablesList {
+					name: "sizeVars"
+					source: [
+						{ name: "allVariablesList", use: "type=scale|ordinal" },
+						{ name: "allVariablesListRM", use: "type=scale|ordinal" }
+					]
+				}
+
+				AssignedVariablesList {
+					id: sizeVariablePlotBuilder
+					allowedColumns: ["scale", "ordinal"]
+					enabled: sizeByVariable.checked
+					name: "sizeVariablePlotBuilder"
+					title: qsTr("Point Size Variable")
+					singleVariable: true
+					onEnabledChanged: {
+						if (!enabled) {
+							while (count > 0) {
+								itemDoubleClicked(0)
+							}
+						}
+					}
+				}
+
+				Group{
+				columns:2
+				DoubleField {
+					name: "pointSizeMin"
+					label: qsTr("Min point size")
+					value: 1
+
+				}
+				DoubleField {
+					name: "pointSizeMax"
+					label: qsTr("Max point size")
+					value: 4
+
+				}
+				}
+			}
+
+			VariablesForm{
+				preferredWidth: jaspForm.width - 2 * jaspTheme.contentMargin
+				preferredHeight: 100 * preferencesModel.uiScale
+				visible: shapebyVariable.checked
+				enabled: shapebyVariable.checked
+
+				AvailableVariablesList {
+					name: "shapeVars"
+					source: [
+						{ name: "allVariablesList",   use: "type=nominal|ordinal" },
+						{ name: "allVariablesListRM", use: "type=nominal|ordinal" }
+					]
+				}
+
+
+
+				AssignedVariablesList {
+					id: pointShapeVariable
+					allowedColumns: ["nominal", "ordinal"]
+					name: "pointShapeVariable"
+					title: qsTr("Point Shape Variable")
+					singleVariable: true
+					enabled: shapebyVariable.checked
+					onEnabledChanged: {
+						if (!enabled) {
+							while (count > 0) {
+								itemDoubleClicked(0)
+							}
+						}
+					}
+				}
+
+			}
+
+
+			CheckBox { ///////////////////////
+				name: "addStatEllipse"
+				label: qsTr("Add ellipse")
+				checked: false
+				enabled: addDataPoint.checked
+				columns: 3
+				info: qsTr("Add a statistical ellipse around the points."
+				+ "'Ellipse type' controls the method:"
+				+ "\"t\" assumes a multivariate t-distribution,"
+				+ "\"Normal\" assumes a multivariate normal distribution,"
+				+ "and \"Euclidean\" draws a circle whose radius equals the value of 'Level'")
+				onEnabledChanged: {
+					if (!enabled) {
+						checked = false;
+					}
+				}
+
+				DropDown {
+					name: "ellipseType"
+					label: qsTr("Ellipse type")
+					values: [
+						{ label: qsTr("t"), value: "t" },
+						{ label: qsTr("Normal"), value: "norm" },
+						{ label: qsTr("Euclidean"), value: "euclid"}
+					]
+					indexDefaultValue: 0
+				}
+
+				DoubleField {
+					name: "fillEllipse"
+					label: qsTr("Transparency")
+					value: 0.20
+					min: 0
+					max: 1
+				}
+
+				DoubleField {
+					name: "levelEllipse"
+					label: qsTr("Level")
+					value: 0.95
+					min: 0
+					max: 1
+					info: qsTr("Confidence level (for t and normal ellipse type) or radius (euclidean ellipse type)")
+				}
+
+			} /////////////////////////////////////////
+
+
+			CheckBox {
+				name: "connectRMPlotBuilder"
+				label: qsTr("Connect data points (requires repeated measures)")
+				id: connectRMPlotBuilder
+				checked: false
+				enabled: isRM.value === "RM" & addDataPoint.checked
+				columns: 2
+				onEnabledChanged: {
+					if (!enabled) {
+						checked = false;
+					}
+				}
+
+				DoubleField {
+					name: "lineRMtransparency"
+					label: qsTr("Transparency")
+					value: 0.5
+				}
+
+				DoubleField {
+					name: "lineRMsize"
+					label: qsTr("Line width")
+					value: 0.5
+				}
+
+
+			}
+
+		}
+
+		// -------------------------------------------------------------------
+		// Distributions (histogram, boxplot, violin)
+		// -------------------------------------------------------------------
+		Section {
+			title: qsTr("Distributions (histogram, boxplot, violin)")
+
+			Label {
+				text: qsTr("Required: X OR Y-Axis Variable (histogram); X AND Y-Axis Variables (boxplot, violin)")
+				wrapMode: Text.Wrap
+				color: "black"
+			}
+
+			GridLayout {
+				columns: 3
+				rows: 1
+				rowSpacing: 40
+				columnSpacing: 40
+
+
+				Group{
+
+					// Histogram
+					CheckBox {
+						name: "addHistogram"
+						id: addHistogram
+						label: qsTr("Histogram")
+						info: qsTr("Check this option to create histogram for x or y variables. Histogram requires either X-Axis or X-Axis variable, but not both.")
+						enabled: (variableXPlotBuilder.count > 0 || variableYPlotBuilder.count > 0)
+								 && !(variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+
+						onEnabledChanged: {
+							if (!enabled) {
+								checked = false;
+							}
+						}
+
+						DoubleField {
+							name: "binsPlotBuilder"
+							label: qsTr("Number of bins")
+							info: qsTr("Sets the number of bins used to divide the data range in histograms."
+									 + "More bins give finer detail, fewer bins give a more general overview")
+							id: binsPlotBuilder
+							defaultValue: 30
+						}
+
+						DoubleField {
+							name: "alphaHistogramPlotBuilder"
+							label: qsTr("Transparency")
+							id: alphaHistogramPlotBuilder
+							defaultValue: 0.8
+							info: qsTr("Set the transparency")
+							min: 0
+							max: 1
+						}
+
+						CheckBox{
+						name: "blackHistogramOutline"
+						label: qsTr("Black outline")
+						}
+					}
+
+					// Density
+
+					CheckBox {
+						name: "addDensity"
+						id: addDensity
+						label: qsTr("Density")
+						info: qsTr("Check this option to overlay a density estimate on the histogram. Density can be shown as scaled (0–1) or on the histogram count scale.")
+						enabled: (variableXPlotBuilder.count > 0 || variableYPlotBuilder.count > 0)
+								 && !(variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+
+						// Density overlay mode radiobutton
+						RadioButtonGroup {
+							id: densityOverlayMode
+							name: "densityOverlayMode"
+							title: qsTr("Density overlay mode")
+							radioButtonsOnSameRow: false
+							columns: 1
+							info: qsTr("Choose whether the density curve is scaled to the histogram count ('Count'), or normalized to a maximum of 1 ('Scaled')")
+
+							RadioButton {
+								label: qsTr("Count")
+								info: qsTr("Show density on the histogram count scale (area under the curve equals total count)")
+								value: "count"
+								id: densityCount
+								checked: true
+							}
+
+							RadioButton {
+								label: qsTr("Scaled (0–1)")
+								info: qsTr("Show density scaled so that the maximum of the curve is 1")
+								value: "scaled"
+								id: densityScaled
+							}
+						}
+
+						DoubleField {
+							name: "alphaDensityPlotBuilder"
+							label: qsTr("Transparency")
+							id: alphaDensityPlotBuilder
+							defaultValue: 0.8
+							info: qsTr("Set the transparency for the density overlay")
+							min: 0
+							max: 1
+						}
+
+						DoubleField {
+							name: "lineWidthDensity"
+							label: qsTr("Line width")
+							id: lineWidthDensity
+							defaultValue: 0.8
+							info: qsTr("Set the line width for the density overlay")
+
+						}
+
+						CheckBox{
+						name: "blackDensityOutline"
+						label: qsTr("Black outline")
+						}
+					}
+
+				}
+
+
+
+				// Boxplot
+
+
 				CheckBox {
-					name: "addDataPoint"
-					label: qsTr("Individual data points")
-					id: addDataPoint
-					info: qsTr("Check this option to show individual data points on the plot")
-					columns: 4
+					name: "addBoxplot"
+					id: addBoxplot
+					label: qsTr("Boxplot")
+					info: qsTr("Check this option to create boxplot. Boxplot and violin plot require both X-Axis and Y-Axis variables.")
 					enabled: (
 								 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
 								 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
@@ -356,257 +780,237 @@ Form {
 						}
 					}
 
-					Group {
-						DoubleField {
-							info: qsTr("Set the point size")
-							name: "pointsizePlotBuilder"
-							id: pointsizePlotBuilder
-							label: qsTr("Point size")
-							enabled: !sizeByVariable.checked
-							value: 3
-							min: 0
-							max: 10
-						}
-
-						CheckBox{
-						name:"sizeByVariable"
-						id: sizeByVariable
-						label: qsTr("Size by variable")
-						info: qsTr("Choose this if you want the point size to be determined by a variable rather than a fixed constant")
-						}
-
-						CheckBox{
-						name:"shapebyVariable"
-						id: shapebyVariable
-						label: qsTr("Shape by variable")
-						info: qsTr("Choose this if you want the point shape to be determined by a variable")
-						}
-					}
-
-					Group {
-						DoubleField {
-							info: "A small “jitter” is added to the individual data points displayed to prevent overlaps. Here you can adjust the height of the jitter."
-							name: "jitterhPlotBuilder"
-							id: jitterhPlotBuilder
-							label: qsTr("Jitter height")
-							value: 0.3
-							min: 0
-							max: 10
-						}
-
-						DoubleField {
-							info: "A small “jitter” is added to the individual data points displayed to prevent overlaps. Here you can adjust the width of the jitter."
-							name: "jitterwPlotBuilder"
-							id: jitterwPlotBuilder
-							label: qsTr("Jitter width")
-							value: 0.3
-							min: 0
-							max: 10
-						}
-					}
-
-					Group {
-						DoubleField {
-							name: "alphaPlotBuilder"
-							id: alphaPlotBuilder
-							label: qsTr("Transparency")
-							info: qsTr("Set the transparency")
-							value: 0.5
-							min: 0
-							max: 1
-						}
-
-						DoubleField {
-							name: "pointDodgePlotBuilder"
-							label: qsTr("Dodge")
-							info: qsTr("Adjusts the horizontal “dodge” spacing between subgroup geometric elements. "
-									  + "Only takes effect when a grouping variable is mapped (e.g., male vs. female within each species). "
-									  + "A value of 0 overlays the elements; higher values push the subgroups farther apart")
-							id: pointDodgePlotBuilder
-							defaultValue: 0.8
-						}
-					}
-
-					Group{
-						CheckBox {
-							name: "blackOutlineDataPoint"
-							label: qsTr("Black outline")
-							checked: false
-							enabled: !shapebyVariable.checked
-							info: qsTr("Add a black outline/border to the elements")
-							onEnabledChanged: {
-								if (!enabled) {
-									checked = false;
-								}
-							}
-						}
-
-						CheckBox {
-							name: "whiteBorder"
-							label: qsTr("White outline")
-							checked: false
-							enabled: !shapebyVariable.checked
-							info: qsTr("Add a white outline/border to the elements")
-							onEnabledChanged: {
-								if (!enabled) {
-									checked = false;
-								}
-							}
-						}
-
-						CheckBox {
-							name: "emptyCircles"
-							label: qsTr("Empty circles")
-							checked: false
-							enabled: !shapebyVariable.checked
-							info: qsTr("Remove the fill")
-							onEnabledChanged: {
-								if (!enabled) {
-									checked = false;
-								}
-							}
-						}
-					}
-
-				}
-
-				VariablesForm{
-					visible: sizeByVariable.checked
-					enabled: sizeByVariable.checked
-					preferredWidth: jaspForm.width - 2 * jaspTheme.contentMargin
-					preferredHeight: 100 * preferencesModel.uiScale
-
-					AvailableVariablesList {
-						name: "sizeVars"
-						source: [
-							{ name: "allVariablesList", use: "type=scale|ordinal" },
-							{ name: "allVariablesListRM", use: "type=scale|ordinal" }
-						]
-					}
-
-					AssignedVariablesList {
-						id: sizeVariablePlotBuilder
-						allowedColumns: ["scale", "ordinal"]
-						enabled: sizeByVariable.checked
-						name: "sizeVariablePlotBuilder"
-						title: qsTr("Point Size Variable")
-						singleVariable: true
-						onEnabledChanged: {
-							if (!enabled) {
-								while (count > 0) {
-									itemDoubleClicked(0)
-								}
-							}
-						}
-					}
-
-					Group{
-					columns:2
 					DoubleField {
-						name: "pointSizeMin"
-						label: qsTr("Min point size")
-						value: 1
+						name: "dodgeBoxplotPlotBuilder"
+						label: qsTr("Dodge")
+						id: dodgeBoxplotPlotBuilder
+						info: qsTr("Adjusts the horizontal “dodge” spacing between subgroup geometric elements. "
+								  + "Only takes effect when a grouping variable is mapped (e.g., male vs. female within each species). "
+								  + "A value of 0 overlays the elements; higher values push the subgroups farther apart")
+						defaultValue: 0.8}
 
-					}
+
 					DoubleField {
-						name: "pointSizeMax"
-						label: qsTr("Max point size")
-						value: 4
+						name: "alphaBoxplotPlotBuilder"
+						label: qsTr("Transparency")
+						id: alphaBoxplotPlotBuilder
+						info: qsTr("Set the transparency")
+						defaultValue: 0.8
+						min: 0
+						max: 1
+					}
 
+					DoubleField {
+						name: "widthLineBoxplotPlotBuilder"
+						label: qsTr("Line width")
+						id: widthLineBoxplotPlotBuilder
+						info: qsTr("Sets the line width of the geometric element (e.g., boxplot, violin, error bar). "
+								 + "Increase for thicker outlines, decrease for thinner ones")
+						defaultValue: 0.8
 					}
+
+					DoubleField {
+						name: "widthBoxplotPlotBuilder"
+						label: qsTr("Boxplot width")
+						info: qsTr("Set the width of the boxplots")
+						id: widthBoxplotPlotBuilder
+						defaultValue: 0.6
 					}
+
+					DoubleField {
+						name: "widthWhiskersPlotBuilder"
+						label: qsTr("Whiskers width")
+						info: qsTr("Sets the horizontal width of the whiskers in a boxplot")
+						id: widthWhiskersPlotBuilder
+						defaultValue: 0.3
+					}
+
+					CheckBox {
+						name: "outlierBoxplotPlotBuilder"
+						label: qsTr("Show outliers")
+						id: outlierBoxplotPlotBuilder
+						info: qsTr("Displays individual outlier points beyond the whiskers in a boxplot. "
+									 + "Outliers are defined as values that fall outside the range of Q1 − coef × IQR and Q3 + coef × IQR")
+						checked: false
+					}
+
+					DoubleField {
+						name: "outlierCoefBoxplotPlotBuilder"
+						label: qsTr("Outlier coef")
+						info: qsTr("Sets the multiplier (coef) used to define outliers in a boxplot. "
+									+ "Outliers are values beyond Q1 − coef × IQR or Q3 + coef × IQR")
+						id: outlierCoefoxplotPlotBuilder
+						defaultValue: 1.5
+					}
+
+					DoubleField {
+						name: "outlierSizeBoxplotPlotBuilder"
+						label: qsTr("Outlier size")
+						info: qsTr("Set the size of the outliers")
+						id: outlierSizeBoxplotPlotBuilder
+						defaultValue: 1
+					}
+
+					CheckBox {
+						name: "blackOutlineBoxplot"
+						label: qsTr("Black outline")
+						checked: true
+						info: qsTr("Add a black outline/border to the elements")
+					}
+
+					CheckBox {
+						name: "whiteOutlineBoxplot"
+						info: qsTr("Add a white outline/border to the elements")
+						label: qsTr("White outline")
+					}
+
+
 				}
 
-				VariablesForm{
-					preferredWidth: jaspForm.width - 2 * jaspTheme.contentMargin
-					preferredHeight: 100 * preferencesModel.uiScale
-					visible: shapebyVariable.checked
-					enabled: shapebyVariable.checke
+				// Violin
+				CheckBox {
+					name: "addViolin"
+					id: addViolin
+					label: qsTr("Violin plot")
+					info: qsTr("Check this option to add a violin plot to your visualization. Boxplot and violin plot require both x-axis and y-axis variables.")
+					enabled: (
+								 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
+								 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
 
-					AvailableVariablesList {
-						name: "shapeVars"
-						source: [
-							{ name: "allVariablesList",   use: "type=nominal|ordinal" },
-							{ name: "allVariablesListRM", use: "type=nominal|ordinal" }
-						]
-					}
+								 ||
 
+								 // 2. If repeated measures (yesRM) and at least one of the following is true:
+								 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
 
+									  xVarRM.count > 0
 
-					AssignedVariablesList {
-						id: pointShapeVariable
-						allowedColumns: ["nominal", "ordinal"]
-						name: "pointShapeVariable"
-						title: qsTr("Point Shape Variable")
-						singleVariable: true
-						enabled: shapebyVariable.checked
-						onEnabledChanged: {
-							if (!enabled) {
-								while (count > 0) {
-									itemDoubleClicked(0)
-								}
-							}
-						}
-					}
+									  ))
+								 )
 
-				}
-
-
-				CheckBox { ///////////////////////
-					name: "addStatEllipse"
-					label: qsTr("Add ellipse")
-					checked: false
-					enabled: addDataPoint.checked
-					columns: 3
-					info: qsTr("Add a statistical ellipse around the points."
-					+ "'Ellipse type' controls the method:"
-					+ "\"t\" assumes a multivariate t-distribution,"
-					+ "\"Normal\" assumes a multivariate normal distribution,"
-					+ "and \"Euclidean\" draws a circle whose radius equals the value of 'Level'")
 					onEnabledChanged: {
 						if (!enabled) {
 							checked = false;
 						}
+					}
+
+					DoubleField {
+						name: "dodgeViolinPlotBuilder"
+						label: qsTr("Dodge")
+						info: qsTr("Adjusts the horizontal “dodge” spacing between subgroup geometric elements. "
+								  + "Only takes effect when a grouping variable is mapped (e.g., male vs. female within each species). "
+								  + "A value of 0 overlays the elements; higher values push the subgroups farther apart")
+						defaultValue: 0.8
+					}
+
+					DoubleField {
+						name: "alphaViolinPlotBuilder"
+						label: qsTr("Transparency")
+						id: alphaViolinPlotBuilder
+						defaultValue: 0.8
+						info: qsTr("Set the transparency")
+						min: 0
+						max: 1
+					}
+
+					DoubleField {
+						name: "linewidthViolinPlotBuilder"
+						label: qsTr("Line width")
+						info: qsTr("Sets the line width of the geometric element (e.g., boxplot, violin, error bar). "
+								 + "Increase for thicker outlines, decrease for thinner ones")
+						id: linewidthViolinPlotBuilder
+						defaultValue: 0.8
 					}
 
 					DropDown {
-						name: "ellipseType"
-						label: qsTr("Ellipse type")
+						name: "scaleViolinPlotBuilder"
+						label: qsTr("Scale method")
+						info: qsTr("Controls how the width of each violin is scaled:"
+								 + "<b>Area</b>: all violins have the same area (default in ggplot2)."
+								 + "<b>Count</b>: violins are scaled by the number of observations in each group."
+								 + "<b>Width</b>: all violins have the same maximum width, regardless of group size.")
+						id: scaleViolinPlotBuilder
 						values: [
-							{ label: qsTr("t"), value: "t" },
-							{ label: qsTr("Normal"), value: "norm" },
-							{ label: qsTr("Euclidean"), value: "euclid"}
+							{ label: qsTr("Area"), value: "area" },
+							{ label: qsTr("Count"), value: "count" },
+							{ label: qsTr("Width"), value: "width" }
 						]
-						indexDefaultValue: 0
+						indexDefaultValue: 2
 					}
 
-					DoubleField {
-						name: "fillEllipse"
-						label: qsTr("Transparency")
-						value: 0.20
-						min: 0
-						max: 1
+					FormulaField {
+						name: "drawQuantilesViolinPlotBuilder"
+						label: qsTr("Draw quantiles")
+						info: qsTr("Draws horizontal lines at the specified quantiles inside each violin. "
+								 + "Use comma-separated values between 0 and 1 (e.g., 0.25, 0.5, 0.75) to show quartiles or other custom quantiles.")
+						defaultValue: "0.25, 0.5, 0.75"
 					}
 
-					DoubleField {
-						name: "levelEllipse"
-						label: qsTr("Level")
-						value: 0.95
-						min: 0
-						max: 1
-						info: qsTr("Confidence level (for t and normal ellipse type) or radius (euclidean ellipse type)")
+					CheckBox {
+						name: "trimViolinPlotBuilder"
+						label: qsTr("Trim violins")
+						id: trimViolinPlotBuilder
+						info: qsTr("If checked, the violins are trimmed to the range of the data. "
+								 + "If unchecked, the density tails may extend beyond the observed values.")
+						checked: false
 					}
 
-				} /////////////////////////////////////////
+					CheckBox {
+						name: "blackOutlineViolin"
+						label: qsTr("Black outline")
+						info: qsTr("Add a black outline/border to the elements")
 
+					}
+
+					CheckBox {
+						name: "whiteOutlineViolin"
+						label: qsTr("White outline")
+						info: qsTr("Add a white outline/border to the elements")
+
+					}
+
+
+				}
+			}
+
+		}
+
+		// -------------------------------------------------------------------
+		// Amounts (count and sum)
+		// -------------------------------------------------------------------
+
+
+
+		Section {
+			title: qsTr("Amounts (count and sum)")
+			info: qsTr("This section adds layers that visualise amounts. "
+					 + "<b>Dodge</b> shifts subgroup geoms sideways so they don’t overlap. "
+					 + "<b>Size / Width</b> sets the thickness of bars and lines or the radius of dots. "
+					 + "<b>Transparency (alpha)</b> controls opacity: 0 = invisible, 1 = solid. "
+					 + "<b>Outline (black / white)</b> toggles a border around the shape. ")
+
+
+
+			Label {
+				text: qsTr("Required: X OR Y-Axis Variable")
+				wrapMode: Text.Wrap
+				color: "black"
+			}
+
+			GridLayout {
+				columns: 3
+				rows: 2
+				rowSpacing: 40
+				columnSpacing: 40
+
+				// Count Bar
 
 				CheckBox {
-					name: "connectRMPlotBuilder"
-					label: qsTr("Connect data points (requires repeated measures)")
-					id: connectRMPlotBuilder
-					checked: false
-					enabled: isRM.value === "RM" & addDataPoint.checked
-					columns: 2
+					name: "addCountBar"
+					label: qsTr("Count bar")
+					info: qsTr("Enable to add a count bar to the plot.")
+					enabled: isRM.value === "noRM" && // can't use if RM
+							 ((variableXPlotBuilder.count > 0 && variableYPlotBuilder.count === 0) ||
+							  (variableXPlotBuilder.count === 0 && variableYPlotBuilder.count > 0))
 					onEnabledChanged: {
 						if (!enabled) {
 							checked = false;
@@ -614,464 +1018,98 @@ Form {
 					}
 
 					DoubleField {
-						name: "lineRMtransparency"
-						label: qsTr("Transparency")
-						value: 0.5
+						name: "dodgeCountBar"
+						label: qsTr("Dodge")
+						defaultValue: 0.8
 					}
 
 					DoubleField {
-						name: "lineRMsize"
+						name: "barwidthCountBar"
+						label: qsTr("Bar width")
+						defaultValue: 0.8
+					}
+					DoubleField {
+						name: "alphaCountBar"
+						label: qsTr("Transparency")
+						defaultValue: 1
+						min: 0
+						max: 1
+					}
+				}
+
+				// Count Dash
+				CheckBox {
+					name: "addCountDash"
+					label: qsTr("Count dash")
+					info: qsTr("Enable to add dashed lines to the plot")
+					enabled: isRM.value === "noRM" && // can't use if RM
+							 ((variableXPlotBuilder.count > 0 && variableYPlotBuilder.count === 0) ||
+							  (variableXPlotBuilder.count === 0 && variableYPlotBuilder.count > 0))
+					onEnabledChanged: {
+						if (!enabled) {
+							checked = false;
+						}
+					}
+
+					DoubleField {
+						name: "dodgeCountDash"
+						label: qsTr("Dodge")
+						defaultValue: 0.8
+					}
+					DoubleField {
+						name: "dashwidthCountDash"
+						label: qsTr("Dash width")
+						defaultValue: 0.8
+					}
+
+					DoubleField {
+						name: "linewidthCountDash"
 						label: qsTr("Line width")
-						value: 0.5
+						defaultValue: 1
 					}
-
-
-				}
-
-			}
-
-			// -------------------------------------------------------------------
-			// Distributions (histogram, boxplot, violin)
-			// -------------------------------------------------------------------
-			Section {
-				title: qsTr("Distributions (histogram, boxplot, violin)")
-
-				Label {
-					text: qsTr("Required: X OR Y-Axis Variable (histogram); X AND Y-Axis Variables (boxplot, violin)")
-					wrapMode: Text.Wrap
-					color: "black"
-				}
-
-				GridLayout {
-					columns: 3
-					rows: 1
-					rowSpacing: 40
-					columnSpacing: 40
-
-
-					Group{
-
-						// Histogram
-						CheckBox {
-							name: "addHistogram"
-							id: addHistogram
-							label: qsTr("Histogram")
-							info: qsTr("Check this option to create histogram for x or y variables. Histogram requires either X-Axis or X-Axis variable, but not both.")
-							enabled: (variableXPlotBuilder.count > 0 || variableYPlotBuilder.count > 0)
-									 && !(variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-
-							onEnabledChanged: {
-								if (!enabled) {
-									checked = false;
-								}
-							}
-
-							DoubleField {
-								name: "binsPlotBuilder"
-								label: qsTr("Number of bins")
-								info: qsTr("Sets the number of bins used to divide the data range in histograms."
-										 + "More bins give finer detail, fewer bins give a more general overview")
-								id: binsPlotBuilder
-								defaultValue: 30
-							}
-
-							DoubleField {
-								name: "alphaHistogramPlotBuilder"
-								label: qsTr("Transparency")
-								id: alphaHistogramPlotBuilder
-								defaultValue: 0.8
-								info: qsTr("Set the transparency")
-								min: 0
-								max: 1
-							}
-
-							CheckBox{
-							name: "blackHistogramOutline"
-							label: qsTr("Black outline")
-							}
-						}
-
-						// Density
-
-						CheckBox {
-							name: "addDensity"
-							id: addDensity
-							label: qsTr("Density")
-							info: qsTr("Check this option to overlay a density estimate on the histogram. Density can be shown as scaled (0–1) or on the histogram count scale.")
-							enabled: (variableXPlotBuilder.count > 0 || variableYPlotBuilder.count > 0)
-									 && !(variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-
-							// Density overlay mode radiobutton
-							RadioButtonGroup {
-								id: densityOverlayMode
-								name: "densityOverlayMode"
-								title: qsTr("Density overlay mode")
-								radioButtonsOnSameRow: false
-								columns: 1
-								info: qsTr("Choose whether the density curve is scaled to the histogram count ('Count'), or normalized to a maximum of 1 ('Scaled')")
-
-								RadioButton {
-									label: qsTr("Count")
-									info: qsTr("Show density on the histogram count scale (area under the curve equals total count)")
-									value: "count"
-									id: densityCount
-									checked: true
-								}
-
-								RadioButton {
-									label: qsTr("Scaled (0–1)")
-									info: qsTr("Show density scaled so that the maximum of the curve is 1")
-									value: "scaled"
-									id: densityScaled
-								}
-							}
-
-							DoubleField {
-								name: "alphaDensityPlotBuilder"
-								label: qsTr("Transparency")
-								id: alphaDensityPlotBuilder
-								defaultValue: 0.8
-								info: qsTr("Set the transparency for the density overlay")
-								min: 0
-								max: 1
-							}
-
-							DoubleField {
-								name: "lineWidthDensity"
-								label: qsTr("Line width")
-								id: lineWidthDensity
-								defaultValue: 0.8
-								info: qsTr("Set the line width for the density overlay")
-
-							}
-
-							CheckBox{
-							name: "blackDensityOutline"
-							label: qsTr("Black outline")
-							}
-						}
-
+					DoubleField {
+						name: "alphaCountDash"
+						label: qsTr("Transparency")
+						defaultValue: 1
+						min: 0
+						max: 1
 					}
-
-
-
-					// Boxplot
-
 
 					CheckBox {
-						name: "addBoxplot"
-						id: addBoxplot
-						label: qsTr("Boxplot")
-						info: qsTr("Check this option to create boxplot. Boxplot and violin plot require both X-Axis and Y-Axis variables.")
-						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeBoxplotPlotBuilder"
-							label: qsTr("Dodge")
-							id: dodgeBoxplotPlotBuilder
-							info: qsTr("Adjusts the horizontal “dodge” spacing between subgroup geometric elements. "
-									  + "Only takes effect when a grouping variable is mapped (e.g., male vs. female within each species). "
-									  + "A value of 0 overlays the elements; higher values push the subgroups farther apart")
-							defaultValue: 0.8}
-
-
-						DoubleField {
-							name: "alphaBoxplotPlotBuilder"
-							label: qsTr("Transparency")
-							id: alphaBoxplotPlotBuilder
-							info: qsTr("Set the transparency")
-							defaultValue: 0.8
-							min: 0
-							max: 1
-						}
-
-						DoubleField {
-							name: "widthLineBoxplotPlotBuilder"
-							label: qsTr("Line width")
-							id: widthLineBoxplotPlotBuilder
-							info: qsTr("Sets the line width of the geometric element (e.g., boxplot, violin, error bar). "
-									 + "Increase for thicker outlines, decrease for thinner ones")
-							defaultValue: 0.8
-						}
-
-						DoubleField {
-							name: "widthBoxplotPlotBuilder"
-							label: qsTr("Boxplot width")
-							info: qsTr("Set the width of the boxplots")
-							id: widthBoxplotPlotBuilder
-							defaultValue: 0.6
-						}
-
-						DoubleField {
-							name: "widthWhiskersPlotBuilder"
-							label: qsTr("Whiskers width")
-							info: qsTr("Sets the horizontal width of the whiskers in a boxplot")
-							id: widthWhiskersPlotBuilder
-							defaultValue: 0.3
-						}
-
-						CheckBox {
-							name: "outlierBoxplotPlotBuilder"
-							label: qsTr("Show outliers")
-							id: outlierBoxplotPlotBuilder
-							info: qsTr("Displays individual outlier points beyond the whiskers in a boxplot. "
-										 + "Outliers are defined as values that fall outside the range of Q1 − coef × IQR and Q3 + coef × IQR")
-							checked: false
-						}
-
-						DoubleField {
-							name: "outlierCoefBoxplotPlotBuilder"
-							label: qsTr("Outlier coef")
-							info: qsTr("Sets the multiplier (coef) used to define outliers in a boxplot. "
-										+ "Outliers are values beyond Q1 − coef × IQR or Q3 + coef × IQR")
-							id: outlierCoefoxplotPlotBuilder
-							defaultValue: 1.5
-						}
-
-						DoubleField {
-							name: "outlierSizeBoxplotPlotBuilder"
-							label: qsTr("Outlier size")
-							info: qsTr("Set the size of the outliers")
-							id: outlierSizeBoxplotPlotBuilder
-							defaultValue: 1
-						}
-
-						CheckBox {
-							name: "blackOutlineBoxplot"
-							label: qsTr("Black outline")
-							checked: true
-							info: qsTr("Add a black outline/border to the elements")
-						}
-
-						CheckBox {
-							name: "whiteOutlineBoxplot"
-							info: qsTr("Add a white outline/border to the elements")
-							label: qsTr("White outline")
-						}
-
-
-					}
-
-					// Violin
-					CheckBox {
-						name: "addViolin"
-						id: addViolin
-						label: qsTr("Violin plot")
-						info: qsTr("Check this option to add a violin plot to your visualization. Boxplot and violin plot require both x-axis and y-axis variables.")
-						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeViolinPlotBuilder"
-							label: qsTr("Dodge")
-							info: qsTr("Adjusts the horizontal “dodge” spacing between subgroup geometric elements. "
-									  + "Only takes effect when a grouping variable is mapped (e.g., male vs. female within each species). "
-									  + "A value of 0 overlays the elements; higher values push the subgroups farther apart")
-							defaultValue: 0.8
-						}
-
-						DoubleField {
-							name: "alphaViolinPlotBuilder"
-							label: qsTr("Transparency")
-							id: alphaViolinPlotBuilder
-							defaultValue: 0.8
-							info: qsTr("Set the transparency")
-							min: 0
-							max: 1
-						}
-
-						DoubleField {
-							name: "linewidthViolinPlotBuilder"
-							label: qsTr("Line width")
-							info: qsTr("Sets the line width of the geometric element (e.g., boxplot, violin, error bar). "
-									 + "Increase for thicker outlines, decrease for thinner ones")
-							id: linewidthViolinPlotBuilder
-							defaultValue: 0.8
-						}
-
-						DropDown {
-							name: "scaleViolinPlotBuilder"
-							label: qsTr("Scale method")
-							info: qsTr("Controls how the width of each violin is scaled:"
-									 + "<b>Area</b>: all violins have the same area (default in ggplot2)."
-									 + "<b>Count</b>: violins are scaled by the number of observations in each group."
-									 + "<b>Width</b>: all violins have the same maximum width, regardless of group size.")
-							id: scaleViolinPlotBuilder
-							values: [
-								{ label: qsTr("Area"), value: "area" },
-								{ label: qsTr("Count"), value: "count" },
-								{ label: qsTr("Width"), value: "width" }
-							]
-							indexDefaultValue: 2
-						}
-
-						FormulaField {
-							name: "drawQuantilesViolinPlotBuilder"
-							label: qsTr("Draw quantiles")
-							info: qsTr("Draws horizontal lines at the specified quantiles inside each violin. "
-									 + "Use comma-separated values between 0 and 1 (e.g., 0.25, 0.5, 0.75) to show quartiles or other custom quantiles.")
-							defaultValue: "0.25, 0.5, 0.75"
-						}
-
-						CheckBox {
-							name: "trimViolinPlotBuilder"
-							label: qsTr("Trim violins")
-							id: trimViolinPlotBuilder
-							info: qsTr("If checked, the violins are trimmed to the range of the data. "
-									 + "If unchecked, the density tails may extend beyond the observed values.")
-							checked: false
-						}
-
-						CheckBox {
-							name: "blackOutlineViolin"
-							label: qsTr("Black outline")
-							info: qsTr("Add a black outline/border to the elements")
-
-						}
-
-						CheckBox {
-							name: "whiteOutlineViolin"
-							label: qsTr("White outline")
-							info: qsTr("Add a white outline/border to the elements")
-
-						}
-
-
+						name: "blackOutlineCountDash"
+						label: qsTr("Black dash")
 					}
 				}
 
-			}
-
-			// -------------------------------------------------------------------
-			// Amounts (count and sum)
-			// -------------------------------------------------------------------
-
-
-
-			Section {
-				title: qsTr("Amounts (count and sum)")
-				info: qsTr("This section adds layers that visualise amounts. "
-						 + "<b>Dodge</b> shifts subgroup geoms sideways so they don’t overlap. "
-						 + "<b>Size / Width</b> sets the thickness of bars and lines or the radius of dots. "
-						 + "<b>Transparency (alpha)</b> controls opacity: 0 = invisible, 1 = solid. "
-						 + "<b>Outline (black / white)</b> toggles a border around the shape. ")
-
-
-
-				Label {
-					text: qsTr("Required: X OR Y-Axis Variable")
-					wrapMode: Text.Wrap
-					color: "black"
-				}
-
-				GridLayout {
-					columns: 3
-					rows: 2
-					rowSpacing: 40
-					columnSpacing: 40
-
-					// Count Bar
-
-					CheckBox {
-						name: "addCountBar"
-						label: qsTr("Count bar")
-						info: qsTr("Enable to add a count bar to the plot.")
-						enabled: isRM.value === "noRM" && // can't use if RM
-								 ((variableXPlotBuilder.count > 0 && variableYPlotBuilder.count === 0) ||
-								  (variableXPlotBuilder.count === 0 && variableYPlotBuilder.count > 0))
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeCountBar"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-
-						DoubleField {
-							name: "barwidthCountBar"
-							label: qsTr("Bar width")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "alphaCountBar"
-							label: qsTr("Transparency")
-							defaultValue: 1
-							min: 0
-							max: 1
+				// Count Dot
+				CheckBox {
+					name: "addCountDot"
+					label: qsTr("Count dot")
+					info: qsTr("Enable to add count dots to the plot")
+					enabled: isRM.value === "noRM" && // can't use if RM
+							 ((variableXPlotBuilder.count > 0 && variableYPlotBuilder.count === 0) ||
+							  (variableXPlotBuilder.count === 0 && variableYPlotBuilder.count > 0))
+					onEnabledChanged: {
+						if (!enabled) {
+							checked = false;
 						}
 					}
 
-					// Count Dash
-					CheckBox {
-						name: "addCountDash"
-						label: qsTr("Count dash")
-						info: qsTr("Enable to add dashed lines to the plot")
-						enabled: isRM.value === "noRM" && // can't use if RM
-								 ((variableXPlotBuilder.count > 0 && variableYPlotBuilder.count === 0) ||
-								  (variableXPlotBuilder.count === 0 && variableYPlotBuilder.count > 0))
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
+					DoubleField {
+						name: "dodgeCountDot"
+						label: qsTr("Dodge")
+						defaultValue: 0.8
+					}
+					DoubleField {
+						name: "sizeCountDot"
+						label: qsTr("Dot size")
+						defaultValue: 5
+					}
 
-						DoubleField {
-							name: "dodgeCountDash"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "dashwidthCountDash"
-							label: qsTr("Dash width")
-							defaultValue: 0.8
-						}
 
+					Group {
 						DoubleField {
-							name: "linewidthCountDash"
-							label: qsTr("Line width")
-							defaultValue: 1
-						}
-						DoubleField {
-							name: "alphaCountDash"
+							name: "alphaCountDot"
 							label: qsTr("Transparency")
 							defaultValue: 1
 							min: 0
@@ -1079,2665 +1117,2631 @@ Form {
 						}
 
 						CheckBox {
-							name: "blackOutlineCountDash"
-							label: qsTr("Black dash")
-						}
-					}
-
-					// Count Dot
-					CheckBox {
-						name: "addCountDot"
-						label: qsTr("Count dot")
-						info: qsTr("Enable to add count dots to the plot")
-						enabled: isRM.value === "noRM" && // can't use if RM
-								 ((variableXPlotBuilder.count > 0 && variableYPlotBuilder.count === 0) ||
-								  (variableXPlotBuilder.count === 0 && variableYPlotBuilder.count > 0))
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeCountDot"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "sizeCountDot"
-							label: qsTr("Dot size")
-							defaultValue: 5
-						}
-
-
-						Group {
-							DoubleField {
-								name: "alphaCountDot"
-								label: qsTr("Transparency")
-								defaultValue: 1
-								min: 0
-								max: 1
-							}
-
-							CheckBox {
-								name: "blackOutlineCountDot"
-								label: qsTr("Black outline")
-							}
-
-							CheckBox {
-								name: "whiteOutlineCountDot"
-								label: qsTr("White outline")
-							}
-						}
-					}
-
-					// Count Line
-					CheckBox {
-						name: "addCountLine"
-						label: qsTr("Count line")
-						info: qsTr("Enable to add count lines to the plot")
-						enabled: isRM.value === "noRM" && // can't use if RM
-								 ((variableXPlotBuilder.count > 0 && variableYPlotBuilder.count === 0) ||
-								  (variableXPlotBuilder.count === 0 && variableYPlotBuilder.count > 0))
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeCountLine"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-
-						DoubleField {
-							name: "linewidthCountLine"
-							label: qsTr("Line width")
-							defaultValue: 1
-						}
-
-						DoubleField {
-							name: "alphaCountLine"
-							label: qsTr("Transparency")
-							defaultValue: 1
-							min: 0
-							max: 1
-						}
-
-						CheckBox {
-							name: "blackOutlineCountLine"
-							label: qsTr("Black line")
-						}
-
-					}
-
-					CheckBox {
-						name: "addCountArea"
-						label: qsTr("Count area")
-						info: qsTr("Enable to add a count area to the plot")
-						enabled: isRM.value === "noRM" && // can't use if RM
-								 ((variableXPlotBuilder.count > 0 && variableYPlotBuilder.count === 0) ||
-								  (variableXPlotBuilder.count === 0 && variableYPlotBuilder.count > 0))
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeCountArea"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "alphaCountArea"
-							label: qsTr("Transparency")
-							defaultValue: 1
-							min: 0
-							max: 1
-						}
-					}
-
-					// Count Value
-					CheckBox {
-						name: "addCountValue"
-						label: qsTr("Count value")
-						info: qsTr("Enable to add count values to the plot")
-						enabled: isRM.value === "noRM" &&
-								 (
-									 (variableXPlotBuilder.count > 0 && variableYPlotBuilder.count === 0) ||
-									 (variableXPlotBuilder.count === 0 && variableYPlotBuilder.count > 0)
-									 )
-
-						DoubleField {
-							name: "fontsizeCountValue"
-							label: qsTr("Font size")
-							defaultValue: 14
-						}
-
-						FormulaField {
-							name: "accuracyCountValue"
-							label: qsTr("Accuracy")
-							defaultValue: "0.1"
-						}
-
-						DoubleField {
-							name: "alphaCountValue"
-							label: qsTr("Transparency")
-							defaultValue: 1
-							min: 0
-							max: 1
-						}
-
-						DoubleField {
-							name: "hjustCountValue"
-							label: qsTr("Horizontal justification")
-							defaultValue: 0.5
-							min: -Infinity
-						}
-
-						DoubleField {
-							name: "vjustCountValue"
-							label: qsTr("Vertical justification")
-							defaultValue: -0.5
-							min: -Infinity
-						}
-
-						CheckBox {
-							name: "blackOutlineCountValue"
-							label: qsTr("Black text")
-						}
-					}
-				}
-
-
-				Label {
-					text: qsTr("Required: X AND Y-Axis Variables")
-					wrapMode: Text.Wrap
-					color: "black"
-				}
-
-				GridLayout {
-					columns: 3
-					rows: 2
-					rowSpacing: 40
-					columnSpacing: 40
-
-					// Sum Bar
-					CheckBox {
-						name: "addSumBar"
-						label: qsTr("Sum bar")
-						info: qsTr("Enable to add a sum bar to the plot.")
-						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeSumBar"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "widthSumBar"
-							label: qsTr("Bar width")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "alphaSumBar"
-							label: qsTr("Transparency")
-							defaultValue: 1
-							min: 0
-							max: 1
-						}
-					}
-
-					// Sum Dash
-					CheckBox {
-						name: "addSumDash"
-						label: qsTr("Sum dash")
-						info: qsTr("Enable to add dashed lines to the plot.")
-						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeSumDash"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "widthSumDash"
-							label: qsTr("Dash width")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "linewidthSumDash"
-							label: qsTr("Line width")
-							defaultValue: 1
-						}
-						DoubleField {
-							name: "alphaSumDash"
-							label: qsTr("Transparency")
-							defaultValue: 1
-							min: 0
-							max: 1
-						}
-
-						CheckBox {
-							name: "blackOutlineSumDash"
-							label: qsTr("Black dash")
-						}
-					}
-
-					// Sum Dot
-					CheckBox {
-						name: "addSumDot"
-						label: qsTr("Sum dot")
-						info: qsTr("Enable to add sum dots to the plot.")
-						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeSumDot"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "sizeSumDot"
-							label: qsTr("Dot size")
-							defaultValue: 5
-						}
-						DoubleField {
-							name: "alphaSumDot"
-							label: qsTr("Transparency")
-							defaultValue: 1
-							min: 0
-							max: 1
-						}
-
-						CheckBox {
-							name: "blackOutlineSumDot"
+							name: "blackOutlineCountDot"
 							label: qsTr("Black outline")
 						}
+
 						CheckBox {
-							name: "whiteOutlineSumDot"
+							name: "whiteOutlineCountDot"
 							label: qsTr("White outline")
 						}
 					}
+				}
 
-					// Sum Line
-					CheckBox {
-						name: "addSumLine"
-						label: qsTr("Sum line")
-						info: qsTr("Enable to add a sum line to the plot.")
-						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeSumLine"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "linewidthSumLine"
-							label: qsTr("Line width")
-							defaultValue: 0.5
-						}
-						DoubleField {
-							name: "alphaSumLine"
-							label: qsTr("Transparency")
-							defaultValue: 1
-							min: 0
-							max: 1
-						}
-
-						CheckBox {
-							name: "blackOutlineSumLine"
-							label: qsTr("Black line")
+				// Count Line
+				CheckBox {
+					name: "addCountLine"
+					label: qsTr("Count line")
+					info: qsTr("Enable to add count lines to the plot")
+					enabled: isRM.value === "noRM" && // can't use if RM
+							 ((variableXPlotBuilder.count > 0 && variableYPlotBuilder.count === 0) ||
+							  (variableXPlotBuilder.count === 0 && variableYPlotBuilder.count > 0))
+					onEnabledChanged: {
+						if (!enabled) {
+							checked = false;
 						}
 					}
 
-					// Sum Area
-					CheckBox {
-						name: "addSumArea"
-						label: qsTr("Sum area")
-						info: qsTr("Enable to add a sum area to the plot.")
-						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeSumArea"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "alphaSumArea"
-							label: qsTr("Transparency")
-							defaultValue: 1
-							min: 0
-							max: 1
-						}
-
+					DoubleField {
+						name: "dodgeCountLine"
+						label: qsTr("Dodge")
+						defaultValue: 0.8
 					}
 
-					// Sum Value
+					DoubleField {
+						name: "linewidthCountLine"
+						label: qsTr("Line width")
+						defaultValue: 1
+					}
+
+					DoubleField {
+						name: "alphaCountLine"
+						label: qsTr("Transparency")
+						defaultValue: 1
+						min: 0
+						max: 1
+					}
+
 					CheckBox {
-						name: "addSumValue"
-						label: qsTr("Sum value")
-						info: qsTr("Enable to add sum values to the plot.")
-						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+						name: "blackOutlineCountLine"
+						label: qsTr("Black line")
+					}
 
-									 ||
+				}
 
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
+				CheckBox {
+					name: "addCountArea"
+					label: qsTr("Count area")
+					info: qsTr("Enable to add a count area to the plot")
+					enabled: isRM.value === "noRM" && // can't use if RM
+							 ((variableXPlotBuilder.count > 0 && variableYPlotBuilder.count === 0) ||
+							  (variableXPlotBuilder.count === 0 && variableYPlotBuilder.count > 0))
+					onEnabledChanged: {
+						if (!enabled) {
+							checked = false;
+						}
+					}
 
-										  xVarRM.count > 0
+					DoubleField {
+						name: "dodgeCountArea"
+						label: qsTr("Dodge")
+						defaultValue: 0.8
+					}
+					DoubleField {
+						name: "alphaCountArea"
+						label: qsTr("Transparency")
+						defaultValue: 1
+						min: 0
+						max: 1
+					}
+				}
 
-										  ))
-									 )
+				// Count Value
+				CheckBox {
+					name: "addCountValue"
+					label: qsTr("Count value")
+					info: qsTr("Enable to add count values to the plot")
+					enabled: isRM.value === "noRM" &&
+							 (
+								 (variableXPlotBuilder.count > 0 && variableYPlotBuilder.count === 0) ||
+								 (variableXPlotBuilder.count === 0 && variableYPlotBuilder.count > 0)
+								 )
 
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
+					DoubleField {
+						name: "fontsizeCountValue"
+						label: qsTr("Font size")
+						defaultValue: 14
+					}
 
-						DoubleField {
-							name: "fontsizeSumValue"
-							label: qsTr("Font size")
-							defaultValue: 14
-						}
-						FormulaField {
-							name: "accuracySumValue"
-							label: qsTr("Accuracy")
-							defaultValue: "0.1"
-						}
-						DoubleField {
-							name: "alphaSumValue"
-							label: qsTr("Transparency")
-							defaultValue: 1
-							min: 0
-							max: 1
-						}
-						DoubleField {
-							name: "hjustSumValue"
-							label: qsTr("Horizontal justification")
-							defaultValue: 0.5
-							min: -Infinity
-						}
-						DoubleField {
-							name: "vjustSumValue"
-							label: qsTr("Vertical justification")
-							defaultValue: -0.5
-							min: -Infinity
-						}
+					FormulaField {
+						name: "accuracyCountValue"
+						label: qsTr("Accuracy")
+						defaultValue: "0.1"
+					}
 
-						CheckBox {
-							name: "blackOutlineSumValue"
-							label: qsTr("Black text")
-						}
+					DoubleField {
+						name: "alphaCountValue"
+						label: qsTr("Transparency")
+						defaultValue: 1
+						min: 0
+						max: 1
+					}
+
+					DoubleField {
+						name: "hjustCountValue"
+						label: qsTr("Horizontal justification")
+						defaultValue: 0.5
+						min: -Infinity
+					}
+
+					DoubleField {
+						name: "vjustCountValue"
+						label: qsTr("Vertical justification")
+						defaultValue: -0.5
+						min: -Infinity
+					}
+
+					CheckBox {
+						name: "blackOutlineCountValue"
+						label: qsTr("Black text")
 					}
 				}
 			}
 
-			// -------------------------------------------------------------------
-			// Proportions (bar/area stack)
-			// -------------------------------------------------------------------
 
-			Section {
-				title: qsTr("Proportions")
+			Label {
+				text: qsTr("Required: X AND Y-Axis Variables")
+				wrapMode: Text.Wrap
+				color: "black"
+			}
 
-				info: qsTr("Visualise how each subgroup contributes to the whole "
-						 + "Requires one Group variable plus either an X- or Y-axis variable "
-						 + "Absolute mode stacks raw counts; Relative mode rescales each stack to 0-1 or 0-100 % "
-						 + "Common controls: Transparency sets opacity, Reverse order flips the stack sequence, "
-						 + "Line width outlines area stacks, Replace N/A turns missing groups into a separate slice")
+			GridLayout {
+				columns: 3
+				rows: 2
+				rowSpacing: 40
+				columnSpacing: 40
+
+				// Sum Bar
+				CheckBox {
+					name: "addSumBar"
+					label: qsTr("Sum bar")
+					info: qsTr("Enable to add a sum bar to the plot.")
+					enabled: (
+								 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
+								 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+
+								 ||
+
+								 // 2. If repeated measures (yesRM) and at least one of the following is true:
+								 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
+
+									  xVarRM.count > 0
+
+									  ))
+								 )
+
+					onEnabledChanged: {
+						if (!enabled) {
+							checked = false;
+						}
+					}
+
+					DoubleField {
+						name: "dodgeSumBar"
+						label: qsTr("Dodge")
+						defaultValue: 0.8
+					}
+					DoubleField {
+						name: "widthSumBar"
+						label: qsTr("Bar width")
+						defaultValue: 0.8
+					}
+					DoubleField {
+						name: "alphaSumBar"
+						label: qsTr("Transparency")
+						defaultValue: 1
+						min: 0
+						max: 1
+					}
+				}
+
+				// Sum Dash
+				CheckBox {
+					name: "addSumDash"
+					label: qsTr("Sum dash")
+					info: qsTr("Enable to add dashed lines to the plot.")
+					enabled: (
+								 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
+								 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+
+								 ||
+
+								 // 2. If repeated measures (yesRM) and at least one of the following is true:
+								 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
+
+									  xVarRM.count > 0
+
+									  ))
+								 )
+
+					onEnabledChanged: {
+						if (!enabled) {
+							checked = false;
+						}
+					}
+
+					DoubleField {
+						name: "dodgeSumDash"
+						label: qsTr("Dodge")
+						defaultValue: 0.8
+					}
+					DoubleField {
+						name: "widthSumDash"
+						label: qsTr("Dash width")
+						defaultValue: 0.8
+					}
+					DoubleField {
+						name: "linewidthSumDash"
+						label: qsTr("Line width")
+						defaultValue: 1
+					}
+					DoubleField {
+						name: "alphaSumDash"
+						label: qsTr("Transparency")
+						defaultValue: 1
+						min: 0
+						max: 1
+					}
+
+					CheckBox {
+						name: "blackOutlineSumDash"
+						label: qsTr("Black dash")
+					}
+				}
+
+				// Sum Dot
+				CheckBox {
+					name: "addSumDot"
+					label: qsTr("Sum dot")
+					info: qsTr("Enable to add sum dots to the plot.")
+					enabled: (
+								 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
+								 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+
+								 ||
+
+								 // 2. If repeated measures (yesRM) and at least one of the following is true:
+								 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
+
+									  xVarRM.count > 0
+
+									  ))
+								 )
+
+					onEnabledChanged: {
+						if (!enabled) {
+							checked = false;
+						}
+					}
+
+					DoubleField {
+						name: "dodgeSumDot"
+						label: qsTr("Dodge")
+						defaultValue: 0.8
+					}
+					DoubleField {
+						name: "sizeSumDot"
+						label: qsTr("Dot size")
+						defaultValue: 5
+					}
+					DoubleField {
+						name: "alphaSumDot"
+						label: qsTr("Transparency")
+						defaultValue: 1
+						min: 0
+						max: 1
+					}
+
+					CheckBox {
+						name: "blackOutlineSumDot"
+						label: qsTr("Black outline")
+					}
+					CheckBox {
+						name: "whiteOutlineSumDot"
+						label: qsTr("White outline")
+					}
+				}
+
+				// Sum Line
+				CheckBox {
+					name: "addSumLine"
+					label: qsTr("Sum line")
+					info: qsTr("Enable to add a sum line to the plot.")
+					enabled: (
+								 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
+								 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+
+								 ||
+
+								 // 2. If repeated measures (yesRM) and at least one of the following is true:
+								 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
+
+									  xVarRM.count > 0
+
+									  ))
+								 )
+
+					onEnabledChanged: {
+						if (!enabled) {
+							checked = false;
+						}
+					}
+
+					DoubleField {
+						name: "dodgeSumLine"
+						label: qsTr("Dodge")
+						defaultValue: 0.8
+					}
+					DoubleField {
+						name: "linewidthSumLine"
+						label: qsTr("Line width")
+						defaultValue: 0.5
+					}
+					DoubleField {
+						name: "alphaSumLine"
+						label: qsTr("Transparency")
+						defaultValue: 1
+						min: 0
+						max: 1
+					}
+
+					CheckBox {
+						name: "blackOutlineSumLine"
+						label: qsTr("Black line")
+					}
+				}
+
+				// Sum Area
+				CheckBox {
+					name: "addSumArea"
+					label: qsTr("Sum area")
+					info: qsTr("Enable to add a sum area to the plot.")
+					enabled: (
+								 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
+								 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+
+								 ||
+
+								 // 2. If repeated measures (yesRM) and at least one of the following is true:
+								 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
+
+									  xVarRM.count > 0
+
+									  ))
+								 )
+
+					onEnabledChanged: {
+						if (!enabled) {
+							checked = false;
+						}
+					}
+
+					DoubleField {
+						name: "dodgeSumArea"
+						label: qsTr("Dodge")
+						defaultValue: 0.8
+					}
+					DoubleField {
+						name: "alphaSumArea"
+						label: qsTr("Transparency")
+						defaultValue: 1
+						min: 0
+						max: 1
+					}
+
+				}
+
+				// Sum Value
+				CheckBox {
+					name: "addSumValue"
+					label: qsTr("Sum value")
+					info: qsTr("Enable to add sum values to the plot.")
+					enabled: (
+								 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
+								 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+
+								 ||
+
+								 // 2. If repeated measures (yesRM) and at least one of the following is true:
+								 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
+
+									  xVarRM.count > 0
+
+									  ))
+								 )
+
+					onEnabledChanged: {
+						if (!enabled) {
+							checked = false;
+						}
+					}
+
+					DoubleField {
+						name: "fontsizeSumValue"
+						label: qsTr("Font size")
+						defaultValue: 14
+					}
+					FormulaField {
+						name: "accuracySumValue"
+						label: qsTr("Accuracy")
+						defaultValue: "0.1"
+					}
+					DoubleField {
+						name: "alphaSumValue"
+						label: qsTr("Transparency")
+						defaultValue: 1
+						min: 0
+						max: 1
+					}
+					DoubleField {
+						name: "hjustSumValue"
+						label: qsTr("Horizontal justification")
+						defaultValue: 0.5
+						min: -Infinity
+					}
+					DoubleField {
+						name: "vjustSumValue"
+						label: qsTr("Vertical justification")
+						defaultValue: -0.5
+						min: -Infinity
+					}
+
+					CheckBox {
+						name: "blackOutlineSumValue"
+						label: qsTr("Black text")
+					}
+				}
+			}
+		}
+
+		// -------------------------------------------------------------------
+		// Proportions (bar/area stack)
+		// -------------------------------------------------------------------
+
+		Section {
+			title: qsTr("Proportions")
+
+			info: qsTr("Visualise how each subgroup contributes to the whole "
+					 + "Requires one Group variable plus either an X- or Y-axis variable "
+					 + "Absolute mode stacks raw counts; Relative mode rescales each stack to 0-1 or 0-100 % "
+					 + "Common controls: Transparency sets opacity, Reverse order flips the stack sequence, "
+					 + "Line width outlines area stacks, Replace N/A turns missing groups into a separate slice")
+			columns: 2
+
+			Label {
+				text: qsTr("Required: Group Variable AND X- or Y-Axis Variable")
+				wrapMode: Text.Wrap
+				color: "black"
+				Layout.columnSpan: 2
+			}
+
+			RadioButtonGroup {
+				id: propModeGroup
+				name: "propMode"
+				title: qsTr("Proportion mode")
+				radioButtonsOnSameRow: true
+				columns: 2
+				Layout.columnSpan: 2
+
+				RadioButton {
+					value: "absolute"
+					label: qsTr("Absolute")
+					checked: true
+					info: qsTr("Stack heights show raw counts")
+				}
+				RadioButton {
+					id: relative
+					value: "relative"
+					label: qsTr("Relative")
+					info: qsTr("Each stack is rescaled so its total height equals 100 %")
+				}
+			}
+
+			GridLayout {
+				columns: 3
+				columnSpacing: 40
+
+				CheckBox {
+					name: "addBarStack"
+					label: qsTr("Bar stack")
+					info: qsTr("Add stacked bars for each category using the selected proportion mode")
+					enabled: ( noRM.checked &&
+							   (variableXPlotBuilder.count > 0 || variableYPlotBuilder.count > 0) &&
+							   variableColorPlotBuilder.count > 0 )
+						  || ( yesRM.checked &&
+							   repeatedMeasuresFactors.count > 0 &&
+							   groupVarRM.count > 0 )
+					onEnabledChanged: { if (!enabled) checked = false }
+
+					DoubleField { name: "alphaBarStack";   label: qsTr("Transparency"); defaultValue: 0.8; min: 0; max: 1 }
+					CheckBox    { name: "reverseBarStack"; label: qsTr("Reverse order") }
+				}
+
+				CheckBox {
+					name: "addAreaStack"
+					label: qsTr("Area stack")
+					info: qsTr("Add stacked areas connected across categories")
+					enabled: ( noRM.checked &&
+							   (variableXPlotBuilder.count > 0 || variableYPlotBuilder.count > 0) &&
+							   variableColorPlotBuilder.count > 0 )
+						  || ( yesRM.checked &&
+							   repeatedMeasuresFactors.count > 0 &&
+							   groupVarRM.count > 0 )
+					onEnabledChanged: { if (!enabled) checked = false }
+
+					DoubleField { name: "alphaAreaStack";     label: qsTr("Transparency"); defaultValue: 0.4; min: 0; max: 1 }
+					DoubleField { name: "linewidthAreaStack"; label: qsTr("Line width");  defaultValue: 0.25; min: 0 }
+					CheckBox    { name: "reverseAreaStack";   label: qsTr("Reverse order") }
+					CheckBox    { name: "replaceNaAreaStack"; label: qsTr("Replace N/A"); info: qsTr("Treat missing groups as a separate slice") }
+				}
+
+				CheckBox {
+					name: "asPercentage"
+					label: qsTr("Show as percentages")
+					enabled: relative.checked
+					info: qsTr("Format the relative scale from 0 % to 100 % instead of 0 to 1")
+					onEnabledChanged: { if (!enabled) checked = false }
+				}
+			}
+		}
+
+
+
+		// -------------------------------------------------------------------
+		// Mean
+		// -------------------------------------------------------------------
+		Section {
+			title: qsTr("Mean")
+
+			info: qsTr("Summary layers that display the arithmetic mean of the Y variable for every X (or vice versa). "
+					 + "Requires both X and Y axes mapped. "
+					 + "Mean can be rendered as bar, line, dot, dash, area, or value. "
+					 + "Common controls: <b>Dodge</b> separates sub-groups, <b>Transparency</b> sets opacity, <b>Size/width</b> changes thickness, <b>Outline</b> toggles borders")
+
+			Label {
+				text: qsTr("Required: X AND Y-Axis Variables")
+				wrapMode: Text.Wrap
+				color: "black"
+			}
+
+			GridLayout {
+				columns: 3
+				rowSpacing: 40
+				columnSpacing: 40
+
+				/* ── Mean bar ── */
+				CheckBox {
+					name: "addMeanBar"
+					label: qsTr("Mean bar")
+					info: qsTr("Add mean bars")
+					enabled: (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+						   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+					onEnabledChanged: { if (!enabled) checked = false }
+
+					DoubleField { name: "dodgeMeanBar";  label: qsTr("Dodge");        defaultValue: 0.8 }
+					DoubleField { name: "alphaMeanBar";  label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
+					DoubleField { name: "widthMeanBar";  label: qsTr("Bar width");    defaultValue: 0.8 }
+				}
+
+				/* ── Mean dash ── */
+				CheckBox {
+					name: "addMeanDash"
+					label: qsTr("Mean dash")
+					info: qsTr("Add dashed mean lines")
+					enabled: (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+						   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+					onEnabledChanged: { if (!enabled) checked = false }
+
+					DoubleField { name: "dodgeMeanDash";     label: qsTr("Dodge");       defaultValue: 0.8 }
+					DoubleField { name: "dashwidthMeanDash"; label: qsTr("Dash width");  defaultValue: 0.8 }
+					DoubleField { name: "linewidthMeanDash"; label: qsTr("Line width");  defaultValue: 1 }
+					DoubleField { name: "alphaMeanDash";     label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
+					CheckBox    { name: "blackOutlineMeanDash"; label: qsTr("Black dash") }
+				}
+
+				/* ── Mean dot ── */
+				CheckBox {
+					name: "addMeanDot"
+					label: qsTr("Mean dot")
+					info: qsTr("Add mean dots")
+					enabled: (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+						   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+					onEnabledChanged: { if (!enabled) checked = false }
+
+					DoubleField { name: "dodgeMeanDot"; label: qsTr("Dodge");    defaultValue: 0.8 }
+					DoubleField { name: "sizeMeanDot";  label: qsTr("Dot size"); defaultValue: 5 }
+					DoubleField { name: "alphaMeanDot"; label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
+					CheckBox    { name: "blackOutlineMeanDot"; label: qsTr("Black outline") }
+					CheckBox    { name: "whiteOutlineMeanDot"; label: qsTr("White outline") }
+				}
+
+				/* ── Mean line ── */
+				CheckBox {
+					name: "addMeanLine"
+					label: qsTr("Mean line")
+					info: qsTr("Add mean profile lines")
+					enabled: (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+						   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+					onEnabledChanged: { if (!enabled) checked = false }
+
+					DoubleField { name: "dodgeMeanLine";   label: qsTr("Dodge");      defaultValue: 0.8 }
+					DoubleField { name: "linewidthMeanLine"; label: qsTr("Line width"); defaultValue: 1 }
+					DoubleField { name: "alphaMeanLine";   label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
+					CheckBox    { name: "blackOutlineMeanLine"; label: qsTr("Black line") }
+				}
+
+				/* ── Mean area ── */
+				CheckBox {
+					name: "addMeanArea"
+					label: qsTr("Mean area")
+					info: qsTr("Add filled mean areas")
+					enabled: (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+						   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+					onEnabledChanged: { if (!enabled) checked = false }
+
+					DoubleField { name: "dodgeMeanArea"; label: qsTr("Dodge");        defaultValue: 0.8 }
+					DoubleField { name: "alphaMeanArea"; label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
+				}
+
+				/* ── Mean value ── */
+				CheckBox {
+					name: "addMeanValue"
+					label: qsTr("Mean value")
+					info: qsTr("Add numeric mean labels")
+					enabled: (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+						   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+					onEnabledChanged: { if (!enabled) checked = false }
+
+					DoubleField  { name: "fontsizeMeanValue";  label: qsTr("Font size"); defaultValue: 14 }
+					FormulaField {
+						name: "accuracyMeanValue"
+						label: qsTr("Accuracy")
+						info: qsTr("Sets the rounding increment for the mean value; 0.1 gives one decimal, 0.01 gives two")
+						defaultValue: "0.1"
+					}
+					DoubleField  { name: "alphaMeanValue";     label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
+					DoubleField  { name: "hjustMeanValue";     label: qsTr("Horizontal justification"); defaultValue: 0.5; min: -Infinity }
+					DoubleField  { name: "vjustMeanValue";     label: qsTr("Vertical justification");   defaultValue: -0.5; min: -Infinity }
+					CheckBox     { name: "blackOutlineMeanValue"; label: qsTr("Black text") }
+				}
+			}
+		}
+
+
+
+		// -------------------------------------------------------------------
+		// Median
+		// -------------------------------------------------------------------
+		Section {
+			title: qsTr("Median")
+
+			info: qsTr("Summary layers that display the median of the Y variable for every X (or vice versa). "
+					 + "Requires both X and Y axes mapped. "
+					 + "Median can be rendered as bar, line, dot, dash, area, or value. "
+					 + "Common controls: <b>Dodge</b> separates sub-groups, <b>Transparency</b> sets opacity, <b>Size/width</b> changes thickness, <b>Outline</b> toggles borders")
+
+			Label {
+				text: qsTr("Required: X AND Y-Axis Variables")
+				wrapMode: Text.Wrap
+				color: "black"
+			}
+
+			GridLayout {
+				columns: 3
+				rowSpacing: 40
+				columnSpacing: 40
+
+				/* Median bar ---------------------------------------------------- */
+				CheckBox {
+					name: "addMedianBar"
+					label: qsTr("Median bar")
+					info: qsTr("Add median bars")
+					enabled: (
+								 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+							  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+							 )
+					onEnabledChanged: { if (!enabled) checked = false }
+
+					DoubleField { name: "dodgeMedianBar";  label: qsTr("Dodge");        defaultValue: 0.8 }
+					DoubleField { name: "alphaMedianBar";  label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
+					DoubleField { name: "widthMedianBar";  label: qsTr("Bar width");    defaultValue: 0.8 }
+				}
+
+				/* Median dash --------------------------------------------------- */
+				CheckBox {
+					id: addMedianDash
+					name: "addMedianDash"
+					label: qsTr("Median dash")
+					info: qsTr("Add dashed median lines")
+					enabled: (
+								 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+							  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+							 )
+					onEnabledChanged: { if (!enabled) checked = false }
+
+					DoubleField { name: "dodgeMedianDash";     label: qsTr("Dodge");       defaultValue: 0.8 }
+					DoubleField { name: "dashwidthMedianDash"; label: qsTr("Dash width");  defaultValue: 0.8 }
+					DoubleField { name: "linewidthMedianDash"; label: qsTr("Line width");  defaultValue: 1 }
+					DoubleField { name: "alphaMedianDash";     label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
+					CheckBox    { name: "blackOutlineMedianDash"; label: qsTr("Black dash"); enabled: addMedianDash.checked }
+				}
+
+				/* Median dot ---------------------------------------------------- */
+				CheckBox {
+					id: addMedianDot
+					name: "addMedianDot"
+					label: qsTr("Median dot")
+					info: qsTr("Add median dots")
+					enabled: (
+								 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+							  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+							 )
+					onEnabledChanged: { if (!enabled) checked = false }
+
+					DoubleField { name: "dodgeMedianDot"; label: qsTr("Dodge");    defaultValue: 0.8 }
+					DoubleField { name: "sizeMedianDot";  label: qsTr("Dot size"); defaultValue: 5 }
+					DoubleField { name: "alphaMedianDot"; label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
+					CheckBox    { name: "blackOutlineMedianDot"; label: qsTr("Black outline"); enabled: addMedianDot.checked }
+					CheckBox    { name: "whiteOutlineMedianDot"; label: qsTr("White outline") }
+				}
+
+				/* Median line --------------------------------------------------- */
+				CheckBox {
+					id: addMedianLine
+					name: "addMedianLine"
+					label: qsTr("Median line")
+					info: qsTr("Add median profile lines")
+					enabled: (
+								 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+							  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+							 )
+					onEnabledChanged: { if (!enabled) checked = false }
+
+					DoubleField { name: "dodgeMedianLine";   label: qsTr("Dodge");      defaultValue: 0.8 }
+					DoubleField { name: "linewidthMedianLine"; label: qsTr("Line width"); defaultValue: 1 }
+					DoubleField { name: "alphaMedianLine";   label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
+					CheckBox    { name: "blackOutlineMedianLine"; label: qsTr("Black line"); enabled: addMedianLine.checked }
+				}
+
+				/* Median area --------------------------------------------------- */
+				CheckBox {
+					name: "addMedianArea"
+					label: qsTr("Median area")
+					info: qsTr("Add filled median areas")
+					enabled: (
+								 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+							  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+							 )
+					onEnabledChanged: { if (!enabled) checked = false }
+
+					DoubleField { name: "dodgeMedianArea"; label: qsTr("Dodge");        defaultValue: 0.8 }
+					DoubleField { name: "alphaMedianArea"; label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
+				}
+
+				/* Median value -------------------------------------------------- */
+				CheckBox {
+					name: "addMedianValue"
+					label: qsTr("Median value")
+					info: qsTr("Add numeric median labels")
+					enabled: (
+								 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+							  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+							 )
+					onEnabledChanged: { if (!enabled) checked = false }
+
+					DoubleField  { name: "fontsizeMedianValue";  label: qsTr("Font size"); defaultValue: 14 }
+					FormulaField {
+						name: "accuracyMedianValue"
+						label: qsTr("Accuracy")
+						info: qsTr("Sets the rounding increment for the median value; 0.1 gives one decimal, 0.01 gives two")
+						defaultValue: "0.1"
+					}
+					DoubleField  { name: "alphaMedianValue";     label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
+					DoubleField  { name: "hjustMedianValue";     label: qsTr("Horizontal justification"); defaultValue: 0.5; min: -Infinity }
+					DoubleField  { name: "vjustMedianValue";     label: qsTr("Vertical justification");   defaultValue: -0.5; min: -Infinity }
+					CheckBox     { name: "blackOutlineMedianValue"; label: qsTr("Black text") }
+				}
+			}
+		}
+
+
+		// -------------------------------------------------------------------
+		// Error bars and ribbons (range, sd, sem, 95% CI)
+		// -------------------------------------------------------------------
+
+		Section {
+			title: qsTr("Error bars and ribbons (range, SD, SEM, 95% CI)")
+
+			info: qsTr("Shows variability with vertical bars or shaded ribbons. "
+					 + "Choose <b>Range</b> (min–max), <b>SD</b>, <b>SEM</b>, or <b>95 % CI</b>. "
+					 + "Common controls: <b>Dodge</b> offsets overlapping groups, <b>Width/Line width</b> adjusts thickness, "
+					 + "<b>Transparency</b> sets opacity, <b>Black lines</b> toggles outlines")
+
+			Label {
+				text: qsTr("Required: X AND Y-Axis Variables")
+				wrapMode: Text.Wrap
+				color: "black"
+			}
+
+			Label {
+				text: qsTr("The optimal dodge value is 0 if both X and Y-Axis Variables are continuous")
+				wrapMode: Text.Wrap
+				color: "black"
+			}
+
+			GridLayout {
+				columns: 2
+				rows: 2
+				rowSpacing: 40
+				columnSpacing: 70
+
+				/* Range Error Bar */
+				CheckBox {
+					name: "addRangeErrorBar"
+					label: qsTr("Range error bar")
+					info: qsTr("Add range error bars")
+					enabled: (
+								  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+							   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+							 )
+					onEnabledChanged: { if (!enabled) checked = false }
+
+					DoubleField { name: "dodgeRangeErrorBar";   label: qsTr("Dodge");        defaultValue: 0.8 }
+					DoubleField { name: "widthRangeErrorBar";   label: qsTr("Width");        defaultValue: 0.3 }
+					DoubleField { name: "linewidthRangeErrorBar"; label: qsTr("Line width"); defaultValue: 1 }
+					DoubleField { name: "transparencyRangeErrorBar"; label: qsTr("Transparency"); defaultValue: 1 }
+					CheckBox    { name: "blackOutlineRangeErrorBar"; label: qsTr("Black lines") }
+				}
+
+				/* SD Error Bar */
+				CheckBox {
+					id: addSDErrorBar
+					name: "addSDErrorBar"
+					label: qsTr("SD error bar")
+					info: qsTr("Add SD error bars")
+					enabled: (
+								  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+							   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+							 )
+					onEnabledChanged: { if (!enabled) checked = false }
+
+					DoubleField { name: "dodgeSDErrorBar";   label: qsTr("Dodge");        defaultValue: 0.8 }
+					DoubleField { name: "widthSDErrorBar";   label: qsTr("Width");        defaultValue: 0.3 }
+					DoubleField { name: "linewidthSDErrorBar"; label: qsTr("Line width"); defaultValue: 1 }
+					DoubleField { name: "transparencySDErrorBar"; label: qsTr("Transparency"); defaultValue: 1 }
+					CheckBox    { name: "blackOutlineSDErrorBar"; label: qsTr("Black lines"); enabled: addSDErrorBar.checked }
+				}
+
+				/* SEM Error Bar */
+				CheckBox {
+					id: addSEMErrorBar
+					name: "addSEMErrorBar"
+					label: qsTr("SEM error bar")
+					info: qsTr("Add SEM error bars")
+					enabled: (
+								  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+							   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+							 )
+					onEnabledChanged: { if (!enabled) checked = false }
+
+					DoubleField { name: "dodgeSEMErrorBar";   label: qsTr("Dodge");        defaultValue: 0.8 }
+					DoubleField { name: "widthSEMErrorBar";   label: qsTr("Width");        defaultValue: 0.3 }
+					DoubleField { name: "linewidthSEMErrorBar"; label: qsTr("Line width"); defaultValue: 1 }
+					DoubleField { name: "transparencySEMErrorBar"; label: qsTr("Transparency"); defaultValue: 1 }
+					CheckBox    { name: "blackOutlineSEMErrorBar"; label: qsTr("Black lines"); enabled: addSEMErrorBar.checked }
+				}
+
+				/* 95 % CI Error Bar */
+				CheckBox {
+					name: "addCI95ErrorBar"
+					label: qsTr("95% CI error bar")
+					info: qsTr("Add 95 % CI error bars")
+					enabled: (
+								  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+							   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+							 )
+					onEnabledChanged: { if (!enabled) checked = false }
+
+					DoubleField { name: "dodgeCI95ErrorBar";   label: qsTr("Dodge");        defaultValue: 0.8 }
+					DoubleField { name: "widthCI95ErrorBar";   label: qsTr("Width");        defaultValue: 0.3 }
+					DoubleField { name: "linewidthCI95ErrorBar"; label: qsTr("Line width"); defaultValue: 1 }
+					DoubleField { name: "transparencyCI95ErrorBar"; label: qsTr("Transparency"); defaultValue: 1 }
+					CheckBox    { name: "blackOutlineCI95ErrorBar"; label: qsTr("Black lines") }
+				}
+			}
+
+			GridLayout {
+				columns: 2
+				rowSpacing: 40
+				columnSpacing: 70
+
+				/* Range Ribbon */
+				CheckBox {
+					name: "addRangeRibbon"
+					label: qsTr("Range ribbon")
+					info: qsTr("Add range ribbons")
+					enabled: (
+								  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+							   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+							 )
+					onEnabledChanged: { if (!enabled) checked = false }
+
+					DoubleField { name: "alphaRangeRibbon"; label: qsTr("Transparency"); defaultValue: 0.4; min: 0; max: 1 }
+					CheckBox    { name: "blackOutlineRangeRibbon"; label: qsTr("Black lines") }
+				}
+
+				/* SD Ribbon */
+				CheckBox {
+					id: addSdRibbon
+					name: "addSdRibbon"
+					label: qsTr("SD ribbon")
+					info: qsTr("Add SD ribbons")
+					enabled: (
+								  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+							   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+							 )
+					onEnabledChanged: { if (!enabled) checked = false }
+
+					DoubleField { name: "alphaSdRibbon"; label: qsTr("Transparency"); defaultValue: 0.4; min: 0; max: 1 }
+					CheckBox    { name: "blackOutlineSdRibbon"; label: qsTr("Black lines"); enabled: addSdRibbon.checked }
+				}
+
+				/* SEM Ribbon */
+				CheckBox {
+					name: "addSemRibbon"
+					label: qsTr("SEM ribbon")
+					info: qsTr("Add SEM ribbons")
+					enabled: (
+								  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+							   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+							 )
+					onEnabledChanged: { if (!enabled) checked = false }
+
+					DoubleField { name: "alphaSemRibbon"; label: qsTr("Transparency"); defaultValue: 0.4; min: 0; max: 1 }
+					CheckBox    { name: "blackOutlineSemRibbon"; label: qsTr("Black lines") }
+				}
+
+				/* 95 % CI Ribbon */
+				CheckBox {
+					name: "addCi95Ribbon"
+					label: qsTr("95% CI ribbon")
+					info: qsTr("Add 95 % CI ribbons")
+					enabled: (
+								  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+							   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+							 )
+					onEnabledChanged: { if (!enabled) checked = false }
+
+					DoubleField { name: "alphaCi95Ribbon"; label: qsTr("Transparency"); defaultValue: 0.4; min: 0; max: 1 }
+					CheckBox    { name: "blackOutlineCi95Ribbon"; label: qsTr("Black lines") }
+				}
+			}
+		}
+
+
+		// -------------------------------------------------------------------
+		// Curve fit and reference lines
+		// -------------------------------------------------------------------
+		Section {
+			title: qsTr("Curve fit and reference lines")
+
+			info: qsTr("Fit trend lines or statistical models and add reference or identity lines for comparison. "
+					 + "Curve fitting requires individual data points. "
+					 + "Common controls: <b>Method</b> chooses the model, <b>Line width</b> adjusts thickness, "
+					 + "<b>Dodge</b> separates groups, <b>Transparency</b> sets opacity, and <b>Color</b> selects the line colour")
+
+			Label {
+				text: qsTr("Required: individual data points (Curve fit)")
+				wrapMode: Text.Wrap
+				color: "black"
+			}
+
+			CheckBox {
+				name: "addCurveFitPlotBuilder"
+				label: qsTr("Add curve fit")
+				info: qsTr("Fit a model to the data points")
+				enabled: addDataPoint.checked
+				onEnabledChanged: { if (!enabled) checked = false }
+				columns: 3
+
+				Group {
+					DropDown {
+						name: "curvaFitMethod"
+						label: qsTr("Method")
+						id: curvaFitMethod
+						indexDefaultValue: 0
+						values: [
+							{ label: qsTr("Linear"), value: "lm" },
+							{ label: qsTr("LOESS"),  value: "loess" }
+						]
+					}
+					DoubleField {
+						name: "linewidthCurveFit"
+						label: qsTr("Line width")
+						defaultValue: 1
+					}
+				}
+
+				Group {
+					DoubleField { name: "dodgeCurveFit";        label: qsTr("Dodge");        defaultValue: 0.8; min: 0; max: 1 }
+					DoubleField { name: "transparencyCurveFit"; label: qsTr("Transparency"); defaultValue: 0.2; min: 0; max: 1 }
+				}
+
+				Group {
+					CheckBox { name: "seCurveFit";           label: qsTr("SE");          checked: true }
+					CheckBox { name: "blackOutlineCurveFit"; label: qsTr("Black lines") }
+				}
+			}
+
+			CheckBox {
+				name: "addReferenceLinePlotBuilder"
+				label: qsTr("Add reference line")
+				info: qsTr("Add reference lines")
 				columns: 2
 
-				Label {
-					text: qsTr("Required: Group Variable AND X- or Y-Axis Variable")
-					wrapMode: Text.Wrap
-					color: "black"
-					Layout.columnSpan: 2
+				Group {
+					TextField { name: "xReferenceLine"; label: qsTr("X-axis intercept"); placeholderText: qsTr("e.g. 0.5, or c(1,2)"); fieldWidth: 100 }
+					TextField { name: "yReferenceLine"; label: qsTr("Y-axis intercept"); placeholderText: qsTr("e.g. 0.5, or c(1,2)"); fieldWidth: 100 }
 				}
+
+				Group {
+					DoubleField { name: "linewidhtReferenceLines"; label: qsTr("Line width"); defaultValue: 1 }
+					TextField   { name: "colorReferenceLine";      label: qsTr("Line color"); placeholderText: qsTr("e.g. black, #ff5733"); defaultValue: "lightgray"; fieldWidth: 100 }
+
+					Label {
+						text: qsTr("Note: For available colors, see %1this page%2")
+							  .arg("<a href='https://r-charts.com/colors/' style='color: blue; text-decoration: underline;'>")
+							  .arg("</a>")
+						wrapMode: Text.Wrap
+						textFormat: Text.RichText
+						MouseArea { anchors.fill: parent; onClicked: { Qt.openUrlExternally("https://r-charts.com/colors/") } }
+					}
+				}
+			}
+
+			CheckBox {
+				name: "addIdentityLinePlotBuilder"
+				label: qsTr("Add identity line")
+				info: qsTr("Add identity line (y = x)")
+				CheckBox { name: "reversedirectionIdentityLine"; label: qsTr("Reverse direction") }
+				TextField {
+					name: "colorIdentityLine"; label: qsTr("Line color");
+					placeholderText: qsTr("e.g. black, #ff5733"); defaultValue: "lightgray"; fieldWidth: 100
+				}
+			}
+
+			Label {
+				text: qsTr("Note: For available colors, see %1this page%2")
+					  .arg("<a href='https://r-charts.com/colors/' style='color: blue; text-decoration: underline;'>")
+					  .arg("</a>")
+				wrapMode: Text.Wrap
+				textFormat: Text.RichText
+				MouseArea { anchors.fill: parent; onClicked: { Qt.openUrlExternally("https://r-charts.com/colors/") } }
+			}
+		}
+
+
+		Label {
+			text: qsTr("Axis settings and annotations")
+			wrapMode: Text.Wrap
+			color: "black"
+			font.bold: true
+		}
+
+		// -------------------------------------------------------------------
+		// Adjust axis
+		// -------------------------------------------------------------------
+		Section {
+			columns: 3
+			title: qsTr("X-Axis")
+
+			/* concise, section-level help */
+			info: qsTr("Fine-tune the x-axis")
+
+			TextField {
+				label: qsTr("Title")
+				info: qsTr("Adds a heading")
+				name: "titleXPlotBuilder"
+				placeholderText: qsTr("Enter x-axis title")
+				fieldWidth: 300          /* per earlier code */
+				/* per request, no per-field info here */
+				Layout.columnSpan: 3
+			}
+
+			Group {
+				title: qsTr("Limits")
+				info: qsTr("Sets the range")
+				columns: 1
+				TextField { name: "limitFromX"; label: qsTr("From"); fieldWidth: 40 }
+				TextField { name: "limitToX";   label: qsTr("To");   fieldWidth: 40 }
+			}
+
+			Group {
+				title: qsTr("Breaks")
+				info: qsTr("Positions tick marks")
+				columns: 1
+				TextField { name: "breakFromX"; label: qsTr("From"); fieldWidth: 40 }
+				TextField { name: "breakToX";   label: qsTr("To");   fieldWidth: 40 }
+				TextField { name: "breakByX";   label: qsTr("By");   fieldWidth: 40 }
+			}
+
+			Group {
+				columns: 1
+				title: qsTr("Labels")
+				info: qsTr("Handle rotation, shortening and sorting")
+
+				CheckBox { name: "rotateXLa	bel"; label: qsTr("Rotate") }
+
+				CheckBox {
+					name: "cutShortScale"
+					label: qsTr("Shorten")
+					info: qsTr("Shorten axis labels using K for thousand, M for million, and so on")
+				}
+
+				CheckBox {
+					name: "enableSort"
+					label: qsTr("Sort")
+					checked: false
+
+					DropDown {
+						name: "sortXLabelsOrder"
+						label: qsTr("Order")
+						values: ["Increasing", "Decreasing"]
+						startValue: "Increasing"
+					}
+
+					DropDown {
+						name: "aggregationFun"
+						label: qsTr("By")
+						values: ["mean", "median"]
+						startValue: "Mean"
+					}
+				}
+			}
+
+			ComponentsList {
+				name: "xAxisLabelRenamer"
+				title: qsTr("Rename labels")
+				info: qsTr("Lets you edit them manually")
+				addItemManually: true
+				minimumItems: 0
+				rowComponent: Row {
+					TextField { name: "originalXLabel"; label: qsTr("Original label"); fieldWidth: 100 }
+					TextField { name: "newXLabel";      label: qsTr("New label");      fieldWidth: 150 }
+				}
+			}
+		}
+
+
+		Section {
+			columns: 3
+			title: qsTr("Y-Axis")
+
+			/* concise, section-level help */
+			info: qsTr("Fine-tune the y-axis: <b>Title</b> adds a heading, "
+					 + "<b>Limits</b> sets the range, <b>Breaks</b> positions tick marks, "
+					 + "<b>Labels</b> handle rotation, shortening and sorting, and "
+					 + "<b>Rename labels</b> lets you edit them manually")
+
+			TextField {
+				label: qsTr("Title")
+				info: qsTr("Adds a heading")
+				name: "titleYPlotBuilder"
+				placeholderText: qsTr("Enter y-axis title")
+				fieldWidth: 300
+				Layout.columnSpan: 3
+			}
+
+			Group {
+				title: qsTr("Limits")
+				info: qsTr("Sets the range")
+				columns: 1
+				TextField { name: "limitFromY"; label: qsTr("From"); fieldWidth: 40 }
+				TextField { name: "limitToY";   label: qsTr("To");   fieldWidth: 40 }
+			}
+
+			Group {
+				title: qsTr("Breaks")
+				info: qsTr("Positions tick marks")
+				columns: 1
+				TextField { name: "breakFromY"; label: qsTr("From"); fieldWidth: 40 }
+				TextField { name: "breakToY";   label: qsTr("To");   fieldWidth: 40 }
+				TextField { name: "breakByY";   label: qsTr("By");   fieldWidth: 40 }
+			}
+
+			Group {
+				title: qsTr("Labels")
+				info: qsTr("Handle rotation, shortening and sorting")
+				columns: 1
+
+				CheckBox { name: "rotateYLabel"; label: qsTr("Rotate") }
+
+				CheckBox {
+					name: "cutShortScaleY"
+					label: qsTr("Shorten")
+					info: qsTr("Shorten axis labels using K for thousand, M for million, and so on")
+				}
+
+				CheckBox {
+					name: "enableSortY"
+					label: qsTr("Sort")
+					checked: false
+
+					DropDown {
+						name: "sortYLabelsOrder"
+						label: qsTr("Order")
+						values: ["Increasing", "Decreasing"]
+						startValue: "Increasing"
+					}
+
+					DropDown {
+						name: "aggregationFunY"
+						label: qsTr("By")
+						values: ["mean", "median"]
+						startValue: "mean"
+					}
+				}
+			}
+
+			ComponentsList {
+				name: "yAxisLabelRenamer"
+				title: qsTr("Rename labels")
+				info: qsTr("Lets you edit them manually")
+				addItemManually: true
+				minimumItems: 0
+
+				rowComponent: Row {
+					TextField { name: "originalYLabel"; label: qsTr("Original label"); fieldWidth: 100 }
+					TextField { name: "newYLabel";      label: qsTr("New label");      fieldWidth: 150 }
+				}
+			}
+		}
+
+
+
+		// -------------------------------------------------------------------
+		// Title, caption, annotation
+		// -------------------------------------------------------------------
+		Section {
+			title: qsTr("Title, caption")
+			columns: 1
+
+			info: qsTr("Use these fields to add text to your figure. "
+					 + "<b>Title</b> appears above the plot, while <b>Caption</b> appears below")
+
+			Group {
+				TextField {
+					name: "titlePlotBuilder"
+					label: qsTr("Title")
+					placeholderText: qsTr("Enter the plot title here")
+					fieldWidth: 300
+				}
+			}
+
+			TextArea {
+				title: qsTr("Caption")
+				name: "captionPlotBuilder"
+				height: 100
+			}
+		}
+
+
+		Section {
+			text: qsTr("Annotation and data label")
+
+			info: qsTr("Label points automatically or place custom annotations anywhere. "
+					 + "<b>Label variable</b> shows each point’s value; <b>Custom annotations</b> add free-form text with position controls. "
+					 + "Common controls: <b>Size</b> adjusts text height, <b>White background</b> improves legibility, colour fields accept named or hex colours")
+
+			Label {
+				text: qsTr("Label data by variable")
+				wrapMode: Text.Wrap
+				color: "black"
+			}
+
+			VariablesForm {
+				enabled: addDataPoint.checked
+				preferredWidth: jaspForm.width - 2 * jaspTheme.contentMargin
+				preferredHeight: 100 * preferencesModel.uiScale
+
+				AvailableVariablesList {
+					name: "labelVars"
+					source: [
+						{ name: "allVariablesList",   use: ["type=scale","type=ordinal","type=nominal"] },
+						{ name: "allVariablesListRM", use: ["type=scale","type=ordinal","type=nominal"] }
+					]
+				}
+
+				AssignedVariablesList {
+					name:           "labelVariablePlotBuilder"
+					title:          qsTr("Label variable")
+					allowedColumns: ["scale","ordinal","nominal"]
+					singleVariable: true
+					enabled: addDataPoint.checked
+					onEnabledChanged: {
+						if (!enabled) {
+							while (count > 0) {
+								itemDoubleClicked(0)
+							}
+						}
+					}
+					info: qsTr("Variable whose values will be shown next to each point")
+				}
+
+				Group {
+					columns: 2
+					DoubleField {
+						name:  "fontsizeDataLabels"
+						label: qsTr("Size")
+						value: 4
+						fieldWidth: 50
+					}
+					CheckBox {
+						name:  "backgroundDataLabels"
+						label: qsTr("White background")
+						checked: false
+						Layout.fillWidth: false
+					}
+				}
+			}
+
+			ComponentsList {
+				name: "annotationPlotBuilder"
+				id: annotationPlotBuilder
+				title: qsTr("Custom annotations")
+				addItemManually: true
+				minimumItems: 0
+				enabled: (
+							  (noRM.checked && (variableXPlotBuilder.count > 0 || variableYPlotBuilder.count > 0))
+						   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+						 )
+				onEnabledChanged: {
+					if (!enabled) {
+						for (var i = annotationPlotBuilder.count - 1; i >= 0; --i) {
+							annotationPlotBuilder.removeItem(i)
+						}
+					}
+				}
+
+				rowComponent: Row {
+					Group {
+						title: qsTr("Annotation ") + (rowIndex + 1)
+						columns: 4
+
+						Group {
+							title: qsTr("Label")
+							TextField {
+								name: "annotationText"
+								label: qsTr("Text")
+								placeholderText: qsTr("e.g. p = 0.1, $italic(p)==0.1$")
+								fieldWidth: 100
+							}
+						}
+
+						Group {
+							columns: 2
+							title: qsTr("Position")
+
+							Group {
+								DoubleField {
+									name: "annotationX"
+									label: qsTr("X-Axis")
+									defaultValue: 3
+									fieldWidth: 60
+								}
+								DoubleField {
+									name: "annotationY"
+									label: qsTr("Y-Axis")
+									defaultValue: 3
+									fieldWidth: 60
+								}
+							}
+
+							Group {
+								DropDown {
+									visible: noRM.checked
+									name: "ColumnAnnotation"
+									label: qsTr("Column")
+									values: columnsvariableSplitPlotBuilder.levels
+									enabled: noRM.checked
+									onEnabledChanged: { if (!enabled) currentIndex = -1 }
+								}
+
+								DropDown {
+									name: "RMColumnAnnotation"
+									title: qsTr("Column")
+									visible: yesRM.checked
+									enabled: yesRM.checked
+									values: colSplitRM.columnsNames.length > 0
+											? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(colSplitRM.columnsNames[0])
+											   ? repeatedMeasuresFactors.factorLevelMap[colSplitRM.columnsNames[0]]
+											   : colSplitRM.levels)
+											: []
+									addEmptyValue: groupValue.columnsNames.length === 0
+									placeholderText: qsTr("<No Value>")
+									onEnabledChanged: { if (!enabled) currentIndex = -1 }
+								}
+
+								DropDown {
+									name: "RowAnnotation"
+									label: qsTr("Row")
+									values: rowsvariableSplitPlotBuilder.levels
+									enabled: noRM.checked
+									visible: noRM.checked
+									onEnabledChanged: { if (!enabled) currentIndex = -1 }
+								}
+
+								DropDown {
+									name: "RMRowAnnotation"
+									title: qsTr("Row")
+									visible: yesRM.checked
+									enabled: yesRM.checked
+									values: rowSplitRM.columnsNames.length > 0
+											? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(rowSplitRM.columnsNames[0])
+											   ? repeatedMeasuresFactors.factorLevelMap[rowSplitRM.columnsNames[0]]
+											   : rowSplitRM.levels)
+											: []
+									addEmptyValue: groupValue.columnsNames.length === 0
+									placeholderText: qsTr("<No Value>")
+									onEnabledChanged: { if (!enabled) currentIndex = -1 }
+								}
+
+								DropDown {
+									name: "GridAnnotation"
+									label: qsTr("Grid")
+									values: gridVariablePlotBuilder.levels
+									enabled: noRM.checked
+									visible: noRM.checked
+									onEnabledChanged: { if (!enabled) currentIndex = -1 }
+								}
+
+								DropDown {
+									name: "RMGridAnnotation"
+									title: qsTr("Grid")
+									visible: yesRM.checked
+									enabled: yesRM.checked
+									values: gridVarRM.columnsNames.length > 0
+											? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(gridVarRM.columnsNames[0])
+											   ? repeatedMeasuresFactors.factorLevelMap[gridVarRM.columnsNames[0]]
+											   : gridVarRM.levels)
+											: []
+									addEmptyValue: groupValue.columnsNames.length === 0
+									placeholderText: qsTr("<No Value>")
+									onEnabledChanged: { if (!enabled) currentIndex = -1 }
+								}
+							}
+						}
+
+						Group {
+							title: qsTr("Appearance")
+							DoubleField {
+								name: "annotationSize"
+								label: qsTr("Size")
+								defaultValue: 5.5
+							}
+							TextField {
+								name: "colorText"
+								label: qsTr("Color")
+								placeholderText: qsTr("e.g. black, #ff5733")
+								defaultValue: "black"
+								fieldWidth: 60
+							}
+						}
+					}
+				}
+			}
+		}
+
+
+
+		Label {
+			text: qsTr("Theme, colors, size, and legend")
+			wrapMode: Text.Wrap
+			color: "black"
+			font.bold: true
+		}
+
+
+		Section {
+			title: qsTr("Theme and color")
+
+			/* section-level help */
+			info: qsTr("Choose an overall visual style and how colours are assigned. "
+					 + "<b>Theme</b> applies a preset look, while <b>Font base size</b> scales all text. "
+					 + "<b>Color settings</b> lets you map colour to a variable, pick a palette, or enter custom colours")
+
+			/* ────────────────── Theme & font size ────────────────── */
+			Group {
+				columns: 2
+
+				DropDown {
+					name: "plotStyle"
+					label: qsTr("Theme")
+					values: ["JASP", "ggplotgray", "ggpubr", "PlotBuilder"]
+					indexDefaultValue: 0
+				}
+
+				DoubleField {
+					name: "baseFontSize"
+					label: qsTr("Font base size")
+					value: 18
+				}
+			}
+
+			/* ────────────────── Colour mapping and palettes ────────────────── */
+			Group {
+				title: qsTr("Color settings")
+				info: qsTr("Decide which variable drives colours and select a palette or provide custom hex/named colours")
+				columns: 1
 
 				RadioButtonGroup {
-					id: propModeGroup
-					name: "propMode"
-					title: qsTr("Proportion mode")
+					name: "colorByGroup"
+					title: qsTr("Color by")
+					info: qsTr("Choose what determines element colours")
 					radioButtonsOnSameRow: true
-					columns: 2
-					Layout.columnSpan: 2
+					columns: 4
 
 					RadioButton {
-						value: "absolute"
-						label: qsTr("Absolute")
-						checked: true
-						info: qsTr("Stack heights show raw counts")
+						value: "none"
+						label: qsTr("None")
+						info: qsTr("Uniform colors")
+						enabled: true
+						checked: !colorXRadio.checked && !colorYRadio.checked
+						onEnabledChanged: { if (!enabled && checked) checked = false }
 					}
 					RadioButton {
-						id: relative
-						value: "relative"
-						label: qsTr("Relative")
-						info: qsTr("Each stack is rescaled so its total height equals 100 %")
+						value: "grouping"
+						label: qsTr("Group variable")
+						info: qsTr("Coloring by Group variable")
+						enabled: variableColorPlotBuilder.count > 0 || groupVarRM.count > 0
+						checked: variableColorPlotBuilder.count > 0 || groupVarRM.count > 0
+						onEnabledChanged: { if (!enabled && checked) checked = false }
+					}
+					RadioButton {
+						id: colorXRadio
+						value: "x"
+						label: qsTr("X variable")
+						info: qsTr("Coloring by X variable")
+						enabled: (variableXPlotBuilder.count > 0 && variableColorPlotBuilder.count === 0) || (xVarRM.count > 0 && groupVarRM.count === 0)
+						checked: false
+						onEnabledChanged: { if (!enabled && checked) checked = false }
+					}
+					RadioButton {
+						id: colorYRadio
+						value: "y"
+						label: qsTr("Y variable")
+						info: qsTr("Coloring by Y variable")
+						enabled: (variableYPlotBuilder.count > 0 && variableColorPlotBuilder.count === 0) || (groupVarRM.count === 0)
+						checked: false
+						onEnabledChanged: { if (!enabled && checked) checked = false }
+					}
+					RadioButton {
+						value: "splitColumn"
+						info: qsTr("Apply separate colours in different splits")
+						label: qsTr("Split (column)")
+						enabled: columnsvariableSplitPlotBuilder.count > 0 || colSplitRM.count > 0
+						checked: false
+						onEnabledChanged: { if (!enabled && checked) checked = false }
+					}
+					RadioButton {
+						value: "splitRow"
+						label: qsTr("Split (rows)")
+						info: qsTr("Apply separate colours in different splits")
+						enabled: rowsvariableSplitPlotBuilder.count > 0 || rowSplitRM.count > 0
+						checked: false
+						onEnabledChanged: { if (!enabled && checked) checked = false }
 					}
 				}
 
-				GridLayout {
-					columns: 3
-					columnSpacing: 40
-
-					CheckBox {
-						name: "addBarStack"
-						label: qsTr("Bar stack")
-						info: qsTr("Add stacked bars for each category using the selected proportion mode")
-						enabled: ( noRM.checked &&
-								   (variableXPlotBuilder.count > 0 || variableYPlotBuilder.count > 0) &&
-								   variableColorPlotBuilder.count > 0 )
-							  || ( yesRM.checked &&
-								   repeatedMeasuresFactors.count > 0 &&
-								   groupVarRM.count > 0 )
-						onEnabledChanged: { if (!enabled) checked = false }
-
-						DoubleField { name: "alphaBarStack";   label: qsTr("Transparency"); defaultValue: 0.8; min: 0; max: 1 }
-						CheckBox    { name: "reverseBarStack"; label: qsTr("Reverse order") }
-					}
-
-					CheckBox {
-						name: "addAreaStack"
-						label: qsTr("Area stack")
-						info: qsTr("Add stacked areas connected across categories")
-						enabled: ( noRM.checked &&
-								   (variableXPlotBuilder.count > 0 || variableYPlotBuilder.count > 0) &&
-								   variableColorPlotBuilder.count > 0 )
-							  || ( yesRM.checked &&
-								   repeatedMeasuresFactors.count > 0 &&
-								   groupVarRM.count > 0 )
-						onEnabledChanged: { if (!enabled) checked = false }
-
-						DoubleField { name: "alphaAreaStack";     label: qsTr("Transparency"); defaultValue: 0.4; min: 0; max: 1 }
-						DoubleField { name: "linewidthAreaStack"; label: qsTr("Line width");  defaultValue: 0.25; min: 0 }
-						CheckBox    { name: "reverseAreaStack";   label: qsTr("Reverse order") }
-						CheckBox    { name: "replaceNaAreaStack"; label: qsTr("Replace N/A"); info: qsTr("Treat missing groups as a separate slice") }
-					}
-
-					CheckBox {
-						name: "asPercentage"
-						label: qsTr("Show as percentages")
-						enabled: relative.checked
-						info: qsTr("Format the relative scale from 0 % to 100 % instead of 0 to 1")
-						onEnabledChanged: { if (!enabled) checked = false }
-					}
-				}
-			}
-
-
-
-			// -------------------------------------------------------------------
-			// Mean
-			// -------------------------------------------------------------------
-			Section {
-				title: qsTr("Mean")
-
-				info: qsTr("Summary layers that display the arithmetic mean of the Y variable for every X (or vice versa). "
-						 + "Requires both X and Y axes mapped. "
-						 + "Mean can be rendered as bar, line, dot, dash, area, or value. "
-						 + "Common controls: <b>Dodge</b> separates sub-groups, <b>Transparency</b> sets opacity, <b>Size/width</b> changes thickness, <b>Outline</b> toggles borders")
-
-				Label {
-					text: qsTr("Required: X AND Y-Axis Variables")
-					wrapMode: Text.Wrap
-					color: "black"
+				DropDown {
+					name: "colorsAll"
+					label: qsTr("Color schemes")
+					indexDefaultValue: 0
+					values: [
+						{ label: qsTr("JASP colors: jaspPalette"), value: "jaspPalette" },
+						{ label: qsTr("JASP colors: colorblind"), value: "colorblind" },
+						{ label: qsTr("JASP colors: colorblind2"), value: "colorblind2" },
+						{ label: qsTr("JASP colors: colorblind3"), value: "colorblind3" },
+						{ label: qsTr("JASP colors: sportsTeamsNBA"), value: "sportsTeamsNBA" },
+						{ label: qsTr("JASP colors: ggplot2"), value: "ggplot2" },
+						{ label: qsTr("JASP colors: grandBudapest"), value: "grandBudapest" },
+						{ label: qsTr("JASP colors: gray"), value: "gray" },
+						{ label: qsTr("JASP colors: blue"), value: "blue" },
+						{ label: qsTr("Discrete: Friendly"), value: "colors_discrete_friendly" },
+						{ label: qsTr("Discrete: Seaside"), value: "colors_discrete_seaside" },
+						{ label: qsTr("Discrete: Apple"), value: "colors_discrete_apple" },
+						{ label: qsTr("Discrete: Friendly Long"), value: "colors_discrete_friendly_long" },
+						{ label: qsTr("Discrete: Okabe Ito"), value: "colors_discrete_okabeito" },
+						{ label: qsTr("Discrete: IBM"), value: "colors_discrete_ibm" },
+						{ label: qsTr("Discrete: Metro"), value: "colors_discrete_metro" },
+						{ label: qsTr("Discrete: Candy"), value: "colors_discrete_candy" },
+						{ label: qsTr("Discrete: Alger"), value: "colors_discrete_alger" },
+						{ label: qsTr("Discrete: Rainbow"), value: "colors_discrete_rainbow" },
+						{ label: qsTr("Continuous: Viridis"), value: "colors_continuous_viridis" },
+						{ label: qsTr("Continuous: Magma"), value: "colors_continuous_magma" },
+						{ label: qsTr("Continuous: Inferno"), value: "colors_continuous_inferno" },
+						{ label: qsTr("Continuous: Plasma"), value: "colors_continuous_plasma" },
+						{ label: qsTr("Continuous: Cividis"), value: "colors_continuous_cividis" },
+						{ label: qsTr("Continuous: Rocket"), value: "colors_continuous_rocket" },
+						{ label: qsTr("Continuous: Mako"), value: "colors_continuous_mako" },
+						{ label: qsTr("Continuous: Turbo"), value: "colors_continuous_turbo" },
+						{ label: qsTr("Continuous: Blue Pink Yellow"), value: "colors_continuous_bluepinkyellow" },
+						{ label: qsTr("Diverging: Blue to Red"), value: "colors_diverging_blue2red" },
+						{ label: qsTr("Diverging: Blue to Brown"), value: "colors_diverging_blue2brown" },
+						{ label: qsTr("Diverging: BuRd"), value: "colors_diverging_BuRd" },
+						{ label: qsTr("Diverging: BuYlRd"), value: "colors_diverging_BuYlRd" },
+						{ label: qsTr("Diverging: Spectral"), value: "colors_diverging_spectral" },
+						{ label: qsTr("Diverging: Icefire"), value: "colors_diverging_icefire" }
+					]
 				}
 
-				GridLayout {
-					columns: 3
-					rowSpacing: 40
-					columnSpacing: 40
-
-					/* ── Mean bar ── */
-					CheckBox {
-						name: "addMeanBar"
-						label: qsTr("Mean bar")
-						info: qsTr("Add mean bars")
-						enabled: (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-							   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-						onEnabledChanged: { if (!enabled) checked = false }
-
-						DoubleField { name: "dodgeMeanBar";  label: qsTr("Dodge");        defaultValue: 0.8 }
-						DoubleField { name: "alphaMeanBar";  label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
-						DoubleField { name: "widthMeanBar";  label: qsTr("Bar width");    defaultValue: 0.8 }
-					}
-
-					/* ── Mean dash ── */
-					CheckBox {
-						name: "addMeanDash"
-						label: qsTr("Mean dash")
-						info: qsTr("Add dashed mean lines")
-						enabled: (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-							   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-						onEnabledChanged: { if (!enabled) checked = false }
-
-						DoubleField { name: "dodgeMeanDash";     label: qsTr("Dodge");       defaultValue: 0.8 }
-						DoubleField { name: "dashwidthMeanDash"; label: qsTr("Dash width");  defaultValue: 0.8 }
-						DoubleField { name: "linewidthMeanDash"; label: qsTr("Line width");  defaultValue: 1 }
-						DoubleField { name: "alphaMeanDash";     label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
-						CheckBox    { name: "blackOutlineMeanDash"; label: qsTr("Black dash") }
-					}
-
-					/* ── Mean dot ── */
-					CheckBox {
-						name: "addMeanDot"
-						label: qsTr("Mean dot")
-						info: qsTr("Add mean dots")
-						enabled: (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-							   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-						onEnabledChanged: { if (!enabled) checked = false }
-
-						DoubleField { name: "dodgeMeanDot"; label: qsTr("Dodge");    defaultValue: 0.8 }
-						DoubleField { name: "sizeMeanDot";  label: qsTr("Dot size"); defaultValue: 5 }
-						DoubleField { name: "alphaMeanDot"; label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
-						CheckBox    { name: "blackOutlineMeanDot"; label: qsTr("Black outline") }
-						CheckBox    { name: "whiteOutlineMeanDot"; label: qsTr("White outline") }
-					}
-
-					/* ── Mean line ── */
-					CheckBox {
-						name: "addMeanLine"
-						label: qsTr("Mean line")
-						info: qsTr("Add mean profile lines")
-						enabled: (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-							   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-						onEnabledChanged: { if (!enabled) checked = false }
-
-						DoubleField { name: "dodgeMeanLine";   label: qsTr("Dodge");      defaultValue: 0.8 }
-						DoubleField { name: "linewidthMeanLine"; label: qsTr("Line width"); defaultValue: 1 }
-						DoubleField { name: "alphaMeanLine";   label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
-						CheckBox    { name: "blackOutlineMeanLine"; label: qsTr("Black line") }
-					}
-
-					/* ── Mean area ── */
-					CheckBox {
-						name: "addMeanArea"
-						label: qsTr("Mean area")
-						info: qsTr("Add filled mean areas")
-						enabled: (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-							   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-						onEnabledChanged: { if (!enabled) checked = false }
-
-						DoubleField { name: "dodgeMeanArea"; label: qsTr("Dodge");        defaultValue: 0.8 }
-						DoubleField { name: "alphaMeanArea"; label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
-					}
-
-					/* ── Mean value ── */
-					CheckBox {
-						name: "addMeanValue"
-						label: qsTr("Mean value")
-						info: qsTr("Add numeric mean labels")
-						enabled: (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-							   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-						onEnabledChanged: { if (!enabled) checked = false }
-
-						DoubleField  { name: "fontsizeMeanValue";  label: qsTr("Font size"); defaultValue: 14 }
-						FormulaField {
-							name: "accuracyMeanValue"
-							label: qsTr("Accuracy")
-							info: qsTr("Sets the rounding increment for the mean value; 0.1 gives one decimal, 0.01 gives two")
-							defaultValue: "0.1"
-						}
-						DoubleField  { name: "alphaMeanValue";     label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
-						DoubleField  { name: "hjustMeanValue";     label: qsTr("Horizontal justification"); defaultValue: 0.5; min: -Infinity }
-						DoubleField  { name: "vjustMeanValue";     label: qsTr("Vertical justification");   defaultValue: -0.5; min: -Infinity }
-						CheckBox     { name: "blackOutlineMeanValue"; label: qsTr("Black text") }
-					}
-				}
-			}
-
-
-
-			// -------------------------------------------------------------------
-			// Median
-			// -------------------------------------------------------------------
-			Section {
-				title: qsTr("Median")
-
-				info: qsTr("Summary layers that display the median of the Y variable for every X (or vice versa). "
-						 + "Requires both X and Y axes mapped. "
-						 + "Median can be rendered as bar, line, dot, dash, area, or value. "
-						 + "Common controls: <b>Dodge</b> separates sub-groups, <b>Transparency</b> sets opacity, <b>Size/width</b> changes thickness, <b>Outline</b> toggles borders")
-
-				Label {
-					text: qsTr("Required: X AND Y-Axis Variables")
-					wrapMode: Text.Wrap
-					color: "black"
-				}
-
-				GridLayout {
-					columns: 3
-					rowSpacing: 40
-					columnSpacing: 40
-
-					/* Median bar ---------------------------------------------------- */
-					CheckBox {
-						name: "addMedianBar"
-						label: qsTr("Median bar")
-						info: qsTr("Add median bars")
-						enabled: (
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-								  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-								 )
-						onEnabledChanged: { if (!enabled) checked = false }
-
-						DoubleField { name: "dodgeMedianBar";  label: qsTr("Dodge");        defaultValue: 0.8 }
-						DoubleField { name: "alphaMedianBar";  label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
-						DoubleField { name: "widthMedianBar";  label: qsTr("Bar width");    defaultValue: 0.8 }
-					}
-
-					/* Median dash --------------------------------------------------- */
-					CheckBox {
-						id: addMedianDash
-						name: "addMedianDash"
-						label: qsTr("Median dash")
-						info: qsTr("Add dashed median lines")
-						enabled: (
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-								  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-								 )
-						onEnabledChanged: { if (!enabled) checked = false }
-
-						DoubleField { name: "dodgeMedianDash";     label: qsTr("Dodge");       defaultValue: 0.8 }
-						DoubleField { name: "dashwidthMedianDash"; label: qsTr("Dash width");  defaultValue: 0.8 }
-						DoubleField { name: "linewidthMedianDash"; label: qsTr("Line width");  defaultValue: 1 }
-						DoubleField { name: "alphaMedianDash";     label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
-						CheckBox    { name: "blackOutlineMedianDash"; label: qsTr("Black dash"); enabled: addMedianDash.checked }
-					}
-
-					/* Median dot ---------------------------------------------------- */
-					CheckBox {
-						id: addMedianDot
-						name: "addMedianDot"
-						label: qsTr("Median dot")
-						info: qsTr("Add median dots")
-						enabled: (
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-								  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-								 )
-						onEnabledChanged: { if (!enabled) checked = false }
-
-						DoubleField { name: "dodgeMedianDot"; label: qsTr("Dodge");    defaultValue: 0.8 }
-						DoubleField { name: "sizeMedianDot";  label: qsTr("Dot size"); defaultValue: 5 }
-						DoubleField { name: "alphaMedianDot"; label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
-						CheckBox    { name: "blackOutlineMedianDot"; label: qsTr("Black outline"); enabled: addMedianDot.checked }
-						CheckBox    { name: "whiteOutlineMedianDot"; label: qsTr("White outline") }
-					}
-
-					/* Median line --------------------------------------------------- */
-					CheckBox {
-						id: addMedianLine
-						name: "addMedianLine"
-						label: qsTr("Median line")
-						info: qsTr("Add median profile lines")
-						enabled: (
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-								  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-								 )
-						onEnabledChanged: { if (!enabled) checked = false }
-
-						DoubleField { name: "dodgeMedianLine";   label: qsTr("Dodge");      defaultValue: 0.8 }
-						DoubleField { name: "linewidthMedianLine"; label: qsTr("Line width"); defaultValue: 1 }
-						DoubleField { name: "alphaMedianLine";   label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
-						CheckBox    { name: "blackOutlineMedianLine"; label: qsTr("Black line"); enabled: addMedianLine.checked }
-					}
-
-					/* Median area --------------------------------------------------- */
-					CheckBox {
-						name: "addMedianArea"
-						label: qsTr("Median area")
-						info: qsTr("Add filled median areas")
-						enabled: (
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-								  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-								 )
-						onEnabledChanged: { if (!enabled) checked = false }
-
-						DoubleField { name: "dodgeMedianArea"; label: qsTr("Dodge");        defaultValue: 0.8 }
-						DoubleField { name: "alphaMedianArea"; label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
-					}
-
-					/* Median value -------------------------------------------------- */
-					CheckBox {
-						name: "addMedianValue"
-						label: qsTr("Median value")
-						info: qsTr("Add numeric median labels")
-						enabled: (
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-								  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-								 )
-						onEnabledChanged: { if (!enabled) checked = false }
-
-						DoubleField  { name: "fontsizeMedianValue";  label: qsTr("Font size"); defaultValue: 14 }
-						FormulaField {
-							name: "accuracyMedianValue"
-							label: qsTr("Accuracy")
-							info: qsTr("Sets the rounding increment for the median value; 0.1 gives one decimal, 0.01 gives two")
-							defaultValue: "0.1"
-						}
-						DoubleField  { name: "alphaMedianValue";     label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
-						DoubleField  { name: "hjustMedianValue";     label: qsTr("Horizontal justification"); defaultValue: 0.5; min: -Infinity }
-						DoubleField  { name: "vjustMedianValue";     label: qsTr("Vertical justification");   defaultValue: -0.5; min: -Infinity }
-						CheckBox     { name: "blackOutlineMedianValue"; label: qsTr("Black text") }
-					}
-				}
-			}
-
-
-			// -------------------------------------------------------------------
-			// Error bars and ribbons (range, sd, sem, 95% CI)
-			// -------------------------------------------------------------------
-
-			Section {
-				title: qsTr("Error bars and ribbons (range, SD, SEM, 95% CI)")
-
-				info: qsTr("Shows variability with vertical bars or shaded ribbons. "
-						 + "Choose <b>Range</b> (min–max), <b>SD</b>, <b>SEM</b>, or <b>95 % CI</b>. "
-						 + "Common controls: <b>Dodge</b> offsets overlapping groups, <b>Width/Line width</b> adjusts thickness, "
-						 + "<b>Transparency</b> sets opacity, <b>Black lines</b> toggles outlines")
-
-				Label {
-					text: qsTr("Required: X AND Y-Axis Variables")
-					wrapMode: Text.Wrap
-					color: "black"
-				}
-
-				Label {
-					text: qsTr("The optimal dodge value is 0 if both X and Y-Axis Variables are continuous")
-					wrapMode: Text.Wrap
-					color: "black"
-				}
-
-				GridLayout {
-					columns: 2
-					rows: 2
-					rowSpacing: 40
-					columnSpacing: 70
-
-					/* Range Error Bar */
-					CheckBox {
-						name: "addRangeErrorBar"
-						label: qsTr("Range error bar")
-						info: qsTr("Add range error bars")
-						enabled: (
-									  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-								   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-								 )
-						onEnabledChanged: { if (!enabled) checked = false }
-
-						DoubleField { name: "dodgeRangeErrorBar";   label: qsTr("Dodge");        defaultValue: 0.8 }
-						DoubleField { name: "widthRangeErrorBar";   label: qsTr("Width");        defaultValue: 0.3 }
-						DoubleField { name: "linewidthRangeErrorBar"; label: qsTr("Line width"); defaultValue: 1 }
-						DoubleField { name: "transparencyRangeErrorBar"; label: qsTr("Transparency"); defaultValue: 1 }
-						CheckBox    { name: "blackOutlineRangeErrorBar"; label: qsTr("Black lines") }
-					}
-
-					/* SD Error Bar */
-					CheckBox {
-						id: addSDErrorBar
-						name: "addSDErrorBar"
-						label: qsTr("SD error bar")
-						info: qsTr("Add SD error bars")
-						enabled: (
-									  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-								   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-								 )
-						onEnabledChanged: { if (!enabled) checked = false }
-
-						DoubleField { name: "dodgeSDErrorBar";   label: qsTr("Dodge");        defaultValue: 0.8 }
-						DoubleField { name: "widthSDErrorBar";   label: qsTr("Width");        defaultValue: 0.3 }
-						DoubleField { name: "linewidthSDErrorBar"; label: qsTr("Line width"); defaultValue: 1 }
-						DoubleField { name: "transparencySDErrorBar"; label: qsTr("Transparency"); defaultValue: 1 }
-						CheckBox    { name: "blackOutlineSDErrorBar"; label: qsTr("Black lines"); enabled: addSDErrorBar.checked }
-					}
-
-					/* SEM Error Bar */
-					CheckBox {
-						id: addSEMErrorBar
-						name: "addSEMErrorBar"
-						label: qsTr("SEM error bar")
-						info: qsTr("Add SEM error bars")
-						enabled: (
-									  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-								   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-								 )
-						onEnabledChanged: { if (!enabled) checked = false }
-
-						DoubleField { name: "dodgeSEMErrorBar";   label: qsTr("Dodge");        defaultValue: 0.8 }
-						DoubleField { name: "widthSEMErrorBar";   label: qsTr("Width");        defaultValue: 0.3 }
-						DoubleField { name: "linewidthSEMErrorBar"; label: qsTr("Line width"); defaultValue: 1 }
-						DoubleField { name: "transparencySEMErrorBar"; label: qsTr("Transparency"); defaultValue: 1 }
-						CheckBox    { name: "blackOutlineSEMErrorBar"; label: qsTr("Black lines"); enabled: addSEMErrorBar.checked }
-					}
-
-					/* 95 % CI Error Bar */
-					CheckBox {
-						name: "addCI95ErrorBar"
-						label: qsTr("95% CI error bar")
-						info: qsTr("Add 95 % CI error bars")
-						enabled: (
-									  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-								   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-								 )
-						onEnabledChanged: { if (!enabled) checked = false }
-
-						DoubleField { name: "dodgeCI95ErrorBar";   label: qsTr("Dodge");        defaultValue: 0.8 }
-						DoubleField { name: "widthCI95ErrorBar";   label: qsTr("Width");        defaultValue: 0.3 }
-						DoubleField { name: "linewidthCI95ErrorBar"; label: qsTr("Line width"); defaultValue: 1 }
-						DoubleField { name: "transparencyCI95ErrorBar"; label: qsTr("Transparency"); defaultValue: 1 }
-						CheckBox    { name: "blackOutlineCI95ErrorBar"; label: qsTr("Black lines") }
-					}
-				}
-
-				GridLayout {
-					columns: 2
-					rowSpacing: 40
-					columnSpacing: 70
-
-					/* Range Ribbon */
-					CheckBox {
-						name: "addRangeRibbon"
-						label: qsTr("Range ribbon")
-						info: qsTr("Add range ribbons")
-						enabled: (
-									  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-								   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-								 )
-						onEnabledChanged: { if (!enabled) checked = false }
-
-						DoubleField { name: "alphaRangeRibbon"; label: qsTr("Transparency"); defaultValue: 0.4; min: 0; max: 1 }
-						CheckBox    { name: "blackOutlineRangeRibbon"; label: qsTr("Black lines") }
-					}
-
-					/* SD Ribbon */
-					CheckBox {
-						id: addSdRibbon
-						name: "addSdRibbon"
-						label: qsTr("SD ribbon")
-						info: qsTr("Add SD ribbons")
-						enabled: (
-									  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-								   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-								 )
-						onEnabledChanged: { if (!enabled) checked = false }
-
-						DoubleField { name: "alphaSdRibbon"; label: qsTr("Transparency"); defaultValue: 0.4; min: 0; max: 1 }
-						CheckBox    { name: "blackOutlineSdRibbon"; label: qsTr("Black lines"); enabled: addSdRibbon.checked }
-					}
-
-					/* SEM Ribbon */
-					CheckBox {
-						name: "addSemRibbon"
-						label: qsTr("SEM ribbon")
-						info: qsTr("Add SEM ribbons")
-						enabled: (
-									  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-								   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-								 )
-						onEnabledChanged: { if (!enabled) checked = false }
-
-						DoubleField { name: "alphaSemRibbon"; label: qsTr("Transparency"); defaultValue: 0.4; min: 0; max: 1 }
-						CheckBox    { name: "blackOutlineSemRibbon"; label: qsTr("Black lines") }
-					}
-
-					/* 95 % CI Ribbon */
-					CheckBox {
-						name: "addCi95Ribbon"
-						label: qsTr("95% CI ribbon")
-						info: qsTr("Add 95 % CI ribbons")
-						enabled: (
-									  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-								   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-								 )
-						onEnabledChanged: { if (!enabled) checked = false }
-
-						DoubleField { name: "alphaCi95Ribbon"; label: qsTr("Transparency"); defaultValue: 0.4; min: 0; max: 1 }
-						CheckBox    { name: "blackOutlineCi95Ribbon"; label: qsTr("Black lines") }
-					}
-				}
-			}
-
-
-			// -------------------------------------------------------------------
-			// Curve fit and reference lines
-			// -------------------------------------------------------------------
-			Section {
-				title: qsTr("Curve fit and reference lines")
-
-				info: qsTr("Fit trend lines or statistical models and add reference or identity lines for comparison. "
-						 + "Curve fitting requires individual data points. "
-						 + "Common controls: <b>Method</b> chooses the model, <b>Line width</b> adjusts thickness, "
-						 + "<b>Dodge</b> separates groups, <b>Transparency</b> sets opacity, and <b>Color</b> selects the line colour")
-
-				Label {
-					text: qsTr("Required: individual data points (Curve fit)")
-					wrapMode: Text.Wrap
-					color: "black"
-				}
-
-				CheckBox {
-					name: "addCurveFitPlotBuilder"
-					label: qsTr("Add curve fit")
-					info: qsTr("Fit a model to the data points")
-					enabled: addDataPoint.checked
-					onEnabledChanged: { if (!enabled) checked = false }
-					columns: 3
-
-					Group {
-						DropDown {
-							name: "curvaFitMethod"
-							label: qsTr("Method")
-							id: curvaFitMethod
-							indexDefaultValue: 0
-							values: [
-								{ label: qsTr("Linear"), value: "lm" },
-								{ label: qsTr("LOESS"),  value: "loess" }
-							]
-						}
-						DoubleField {
-							name: "linewidthCurveFit"
-							label: qsTr("Line width")
-							defaultValue: 1
-						}
-					}
-
-					Group {
-						DoubleField { name: "dodgeCurveFit";        label: qsTr("Dodge");        defaultValue: 0.8; min: 0; max: 1 }
-						DoubleField { name: "transparencyCurveFit"; label: qsTr("Transparency"); defaultValue: 0.2; min: 0; max: 1 }
-					}
-
-					Group {
-						CheckBox { name: "seCurveFit";           label: qsTr("SE");          checked: true }
-						CheckBox { name: "blackOutlineCurveFit"; label: qsTr("Black lines") }
-					}
-				}
-
-				CheckBox {
-					name: "addReferenceLinePlotBuilder"
-					label: qsTr("Add reference line")
-					info: qsTr("Add reference lines")
-					columns: 2
-
-					Group {
-						TextField { name: "xReferenceLine"; label: qsTr("X-axis intercept"); placeholderText: qsTr("e.g. 0.5, or c(1,2)"); fieldWidth: 100 }
-						TextField { name: "yReferenceLine"; label: qsTr("Y-axis intercept"); placeholderText: qsTr("e.g. 0.5, or c(1,2)"); fieldWidth: 100 }
-					}
-
-					Group {
-						DoubleField { name: "linewidhtReferenceLines"; label: qsTr("Line width"); defaultValue: 1 }
-						TextField   { name: "colorReferenceLine";      label: qsTr("Line color"); placeholderText: qsTr("e.g. black, #ff5733"); defaultValue: "lightgray"; fieldWidth: 100 }
-
-						Label {
-							text: qsTr("Note: For available colors, see %1this page%2")
-								  .arg("<a href='https://r-charts.com/colors/' style='color: blue; text-decoration: underline;'>")
-								  .arg("</a>")
-							wrapMode: Text.Wrap
-							textFormat: Text.RichText
-							MouseArea { anchors.fill: parent; onClicked: { Qt.openUrlExternally("https://r-charts.com/colors/") } }
-						}
-					}
-				}
-
-				CheckBox {
-					name: "addIdentityLinePlotBuilder"
-					label: qsTr("Add identity line")
-					info: qsTr("Add identity line (y = x)")
-					CheckBox { name: "reversedirectionIdentityLine"; label: qsTr("Reverse direction") }
-					TextField {
-						name: "colorIdentityLine"; label: qsTr("Line color");
-						placeholderText: qsTr("e.g. black, #ff5733"); defaultValue: "lightgray"; fieldWidth: 100
-					}
+				TextField {
+					name: "customColors"
+					label: qsTr("Custom colors")
+					info: qsTr("Here you can specify custom colors separated by commas")
+					placeholderText: qsTr("e.g. red, blue, #ff5733")
+					fieldWidth: 150
 				}
 
 				Label {
 					text: qsTr("Note: For available colors, see %1this page%2")
-						  .arg("<a href='https://r-charts.com/colors/' style='color: blue; text-decoration: underline;'>")
-						  .arg("</a>")
+							.arg("<a href='https://r-charts.com/colors/' style='color: blue; text-decoration: underline;'>")
+							.arg("</a>")
 					wrapMode: Text.Wrap
 					textFormat: Text.RichText
-					MouseArea { anchors.fill: parent; onClicked: { Qt.openUrlExternally("https://r-charts.com/colors/") } }
-				}
-			}
-
-
-			Label {
-				text: qsTr("Axis settings and annotations")
-				wrapMode: Text.Wrap
-				color: "black"
-				font.bold: true
-			}
-
-			// -------------------------------------------------------------------
-			// Adjust axis
-			// -------------------------------------------------------------------
-			Section {
-				columns: 3
-				title: qsTr("X-Axis")
-
-				/* concise, section-level help */
-				info: qsTr("Fine-tune the x-axis: <b>Title</b> adds a heading, "
-						 + "<b>Limits</b> sets the range, <b>Breaks</b> positions tick marks, "
-						 + "<b>Labels</b> handle rotation, shortening and sorting, and "
-						 + "<b>Rename labels</b> lets you edit them manually")
-
-				TextField {
-					label: qsTr("Title")
-					name: "titleXPlotBuilder"
-					placeholderText: qsTr("Enter x-axis title")
-					fieldWidth: 300          /* per earlier code */
-					/* per request, no per-field info here */
-					Layout.columnSpan: 3
-				}
-
-				Group {
-					title: qsTr("Limits")
-					columns: 1
-					TextField { name: "limitFromX"; label: qsTr("From"); fieldWidth: 40 }
-					TextField { name: "limitToX";   label: qsTr("To");   fieldWidth: 40 }
-				}
-
-				Group {
-					title: qsTr("Breaks")
-					columns: 1
-					TextField { name: "breakFromX"; label: qsTr("From"); fieldWidth: 40 }
-					TextField { name: "breakToX";   label: qsTr("To");   fieldWidth: 40 }
-					TextField { name: "breakByX";   label: qsTr("By");   fieldWidth: 40 }
-				}
-
-				Group {
-					columns: 1
-					title: qsTr("Labels")
-
-					CheckBox { name: "rotateXLa	bel"; label: qsTr("Rotate") }
-
-					CheckBox {
-						name: "cutShortScale"
-						label: qsTr("Shorten")
-						info: qsTr("Shorten axis labels using K for thousand, M for million, and so on")
-					}
-
-					CheckBox {
-						name: "enableSort"
-						label: qsTr("Sort")
-						checked: false
-
-						DropDown {
-							name: "sortXLabelsOrder"
-							label: qsTr("Order")
-							values: ["Increasing", "Decreasing"]
-							startValue: "Increasing"
-						}
-
-						DropDown {
-							name: "aggregationFun"
-							label: qsTr("By")
-							values: ["mean", "median"]
-							startValue: "Mean"
-						}
-					}
-				}
-
-				ComponentsList {
-					name: "xAxisLabelRenamer"
-					title: qsTr("Rename labels")
-					addItemManually: true
-					minimumItems: 0
-					rowComponent: Row {
-						TextField { name: "originalXLabel"; label: qsTr("Original label"); fieldWidth: 100 }
-						TextField { name: "newXLabel";      label: qsTr("New label");      fieldWidth: 150 }
+					MouseArea {
+						anchors.fill: parent
+						onClicked: { Qt.openUrlExternally("https://r-charts.com/colors/") }
 					}
 				}
 			}
+		}
 
 
-			Section {
-				columns: 3
-				title: qsTr("Y-Axis")
+		Section {
+			title: qsTr("Size, margins and plot orientation")
+			columns: 1
 
-				/* concise, section-level help */
-				info: qsTr("Fine-tune the y-axis: <b>Title</b> adds a heading, "
-						 + "<b>Limits</b> sets the range, <b>Breaks</b> positions tick marks, "
-						 + "<b>Labels</b> handle rotation, shortening and sorting, and "
-						 + "<b>Rename labels</b> lets you edit them manually")
+			/* section-level help */
+			info: qsTr("Control the canvas dimensions and whitespace. "
+					 + "<b>Plot size</b> sets the pixel width × height, "
+					 + "<b>Axis padding</b> adds proportional space inside the axes, "
+					 + "<b>Margins</b> add outer whitespace, and "
+					 + "<b>Plot orientation</b> can flip X and Y")
 
-				TextField {
-					label: qsTr("Title")
-					name: "titleYPlotBuilder"
-					placeholderText: qsTr("Enter y-axis title")
-					fieldWidth: 300
-					Layout.columnSpan: 3
+			Group {
+				title: qsTr("Plot size")
+				info: qsTr("Width and height of the exported figure in pixels")
+				columns: 2
+
+				DoubleField {
+					id: plotWidth
+					name: "widthPlotBuilder"
+					label: qsTr("Width (px)")
+					defaultValue: 380
+					fieldWidth: 50
 				}
 
-				Group {
-					title: qsTr("Limits")
-					columns: 1
-					TextField { name: "limitFromY"; label: qsTr("From"); fieldWidth: 40 }
-					TextField { name: "limitToY";   label: qsTr("To");   fieldWidth: 40 }
-				}
-
-				Group {
-					title: qsTr("Breaks")
-					columns: 1
-					TextField { name: "breakFromY"; label: qsTr("From"); fieldWidth: 40 }
-					TextField { name: "breakToY";   label: qsTr("To");   fieldWidth: 40 }
-					TextField { name: "breakByY";   label: qsTr("By");   fieldWidth: 40 }
-				}
-
-				Group {
-					title: qsTr("Labels")
-					columns: 1
-
-					CheckBox { name: "rotateYLabel"; label: qsTr("Rotate") }
-
-					CheckBox {
-						name: "cutShortScaleY"
-						label: qsTr("Shorten")
-						info: qsTr("Shorten axis labels using K for thousand, M for million, and so on")
-					}
-
-					CheckBox {
-						name: "enableSortY"
-						label: qsTr("Sort")
-						checked: false
-
-						DropDown {
-							name: "sortYLabelsOrder"
-							label: qsTr("Order")
-							values: ["Increasing", "Decreasing"]
-							startValue: "Increasing"
-						}
-
-						DropDown {
-							name: "aggregationFunY"
-							label: qsTr("By")
-							values: ["mean", "median"]
-							startValue: "mean"
-						}
-					}
-				}
-
-				ComponentsList {
-					name: "yAxisLabelRenamer"
-					title: qsTr("Rename labels")
-					addItemManually: true
-					minimumItems: 0
-
-					rowComponent: Row {
-						TextField { name: "originalYLabel"; label: qsTr("Original label"); fieldWidth: 100 }
-						TextField { name: "newYLabel";      label: qsTr("New label");      fieldWidth: 150 }
-					}
+				DoubleField {
+					id: plotHeight
+					name: "heightPlotBuilder"
+					label: qsTr("Height (px)")
+					defaultValue: 300
+					fieldWidth: 50
 				}
 			}
 
+			Group {
+				title: qsTr("Axis padding")
+				info: qsTr("Fraction of the data range to leave empty inside each axis (0 – 1)")
+				columns: 4
+
+				DoubleField { name: "YPaddingSecond"; label: qsTr("Top");    value: 0.05 }
+				DoubleField { name: "YPaddingFirst";  label: qsTr("Bottom"); value: 0.04 }
+				DoubleField { name: "XPaddingFirst";  label: qsTr("Left");   value: 0.05 }
+				DoubleField { name: "XPaddingSecond"; label: qsTr("Right");  value: 0.05 }
+			}
+
+			Group {
+				title: qsTr("Margins")
+				info: qsTr("Outer whitespace around the plot (pts)")
+				columns: 4
+
+				DoubleField { name: "topMargin";    label: qsTr("Top");    value: 10 }
+				DoubleField { name: "bottomMargin"; label: qsTr("Bottom"); value: 10 }
+				DoubleField { name: "leftMargin";   label: qsTr("Left");   value: 10 }
+				DoubleField { name: "rightMargin";  label: qsTr("Right");  value: 10 }
+			}
+
+			Group {
+				title: qsTr("Plot orientation")
+				info: qsTr("Flip swaps the X and Y axes")
+				CheckBox { name: "flipPlot"; label: qsTr("Flip plot") }
+			}
+		}
 
 
-			// -------------------------------------------------------------------
-			// Title, caption, annotation
-			// -------------------------------------------------------------------
-			Section {
-				title: qsTr("Title, caption")
-				columns: 1
+		// -------------------------------------------------------------------
+		// Edit style and colors
+		// -------------------------------------------------------------------
+		Section {
+			title: qsTr("Legend")
 
-				info: qsTr("Use these fields to add text to your figure. "
-						 + "<b>Title</b> appears above the plot, while <b>Caption</b> appears below")
+			info: qsTr("Control where the legend appears and what it shows. "
+					 + "Use <b>Position</b> to dock the legend or hide it. "
+					 + "<b>Remove title</b> hides the legend heading")
 
-				Group {
+			Group {
+				columns: 2
+
+				DropDown {
+					name: "legendPosistionPlotBuilder"
+					label: qsTr("Position")
+					id: legendPosistionPlotBuilder
+					indexDefaultValue: 0
+					fieldWidth: 150
+					values: [
+						{ label: qsTr("Right"),      value: "right" },
+						{ label: qsTr("Left"),       value: "left" },
+						{ label: qsTr("Bottom"),     value: "bottom" },
+						{ label: qsTr("Top"),        value: "top" },
+						{ label: qsTr("No legend"),  value: "none" }
+					]
+				}
+
+				CheckBox {
+					name: "removeLegendTitle"
+					label: qsTr("Remove title")
+				}
+			}
+
+			ComponentsList {
+				name: "colorLabelRenamer"
+				title: qsTr("Rename labels")
+				info: qsTr("Edit the text of individual legend entries")
+				addItemManually: true
+				minimumItems: 0
+
+				rowComponent: Row {
 					TextField {
-						name: "titlePlotBuilder"
-						label: qsTr("Title")
-						placeholderText: qsTr("Enter the plot title here")
-						fieldWidth: 300
+						name: "originalColorLabel"
+						label: qsTr("Original label")
+						fieldWidth: 100
 					}
-				}
-
-				TextArea {
-					title: qsTr("Caption")
-					name: "captionPlotBuilder"
-					height: 100
-				}
-			}
-
-
-			Section {
-				text: qsTr("Annotation and data label")
-
-				info: qsTr("Label points automatically or place custom annotations anywhere. "
-						 + "<b>Label variable</b> shows each point’s value; <b>Custom annotations</b> add free-form text with position controls. "
-						 + "Common controls: <b>Size</b> adjusts text height, <b>White background</b> improves legibility, colour fields accept named or hex colours")
-
-				Label {
-					text: qsTr("Label data by variable")
-					wrapMode: Text.Wrap
-					color: "black"
-				}
-
-				VariablesForm {
-					enabled: addDataPoint.checked
-					preferredWidth: jaspForm.width - 2 * jaspTheme.contentMargin
-					preferredHeight: 100 * preferencesModel.uiScale
-
-					AvailableVariablesList {
-						name: "labelVars"
-						source: [
-							{ name: "allVariablesList",   use: ["type=scale","type=ordinal","type=nominal"] },
-							{ name: "allVariablesListRM", use: ["type=scale","type=ordinal","type=nominal"] }
-						]
-					}
-
-					AssignedVariablesList {
-						name:           "labelVariablePlotBuilder"
-						title:          qsTr("Label variable")
-						allowedColumns: ["scale","ordinal","nominal"]
-						singleVariable: true
-						enabled: addDataPoint.checked
-						onEnabledChanged: {
-							if (!enabled) {
-								while (count > 0) {
-									itemDoubleClicked(0)
-								}
-							}
-						}
-						info: qsTr("Variable whose values will be shown next to each point")
-					}
-
-					Group {
-						columns: 2
-						DoubleField {
-							name:  "fontsizeDataLabels"
-							label: qsTr("Size")
-							value: 4
-							fieldWidth: 50
-						}
-						CheckBox {
-							name:  "backgroundDataLabels"
-							label: qsTr("White background")
-							checked: false
-							Layout.fillWidth: false
-						}
-					}
-				}
-
-				ComponentsList {
-					name: "annotationPlotBuilder"
-					id: annotationPlotBuilder
-					title: qsTr("Custom annotations")
-					addItemManually: true
-					minimumItems: 0
-					enabled: (
-								  (noRM.checked && (variableXPlotBuilder.count > 0 || variableYPlotBuilder.count > 0))
-							   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-							 )
-					onEnabledChanged: {
-						if (!enabled) {
-							for (var i = annotationPlotBuilder.count - 1; i >= 0; --i) {
-								annotationPlotBuilder.removeItem(i)
-							}
-						}
-					}
-
-					rowComponent: Row {
-						Group {
-							title: qsTr("Annotation ") + (rowIndex + 1)
-							columns: 4
-
-							Group {
-								title: qsTr("Label")
-								TextField {
-									name: "annotationText"
-									label: qsTr("Text")
-									placeholderText: qsTr("e.g. p = 0.1, $italic(p)==0.1$")
-									fieldWidth: 100
-								}
-							}
-
-							Group {
-								columns: 2
-								title: qsTr("Position")
-
-								Group {
-									DoubleField {
-										name: "annotationX"
-										label: qsTr("X-Axis")
-										defaultValue: 3
-										fieldWidth: 60
-									}
-									DoubleField {
-										name: "annotationY"
-										label: qsTr("Y-Axis")
-										defaultValue: 3
-										fieldWidth: 60
-									}
-								}
-
-								Group {
-									DropDown {
-										visible: noRM.checked
-										name: "ColumnAnnotation"
-										label: qsTr("Column")
-										values: columnsvariableSplitPlotBuilder.levels
-										enabled: noRM.checked
-										onEnabledChanged: { if (!enabled) currentIndex = -1 }
-									}
-
-									DropDown {
-										name: "RMColumnAnnotation"
-										title: qsTr("Column")
-										visible: yesRM.checked
-										enabled: yesRM.checked
-										values: colSplitRM.columnsNames.length > 0
-												? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(colSplitRM.columnsNames[0])
-												   ? repeatedMeasuresFactors.factorLevelMap[colSplitRM.columnsNames[0]]
-												   : colSplitRM.levels)
-												: []
-										addEmptyValue: groupValue.columnsNames.length === 0
-										placeholderText: qsTr("<No Value>")
-										onEnabledChanged: { if (!enabled) currentIndex = -1 }
-									}
-
-									DropDown {
-										name: "RowAnnotation"
-										label: qsTr("Row")
-										values: rowsvariableSplitPlotBuilder.levels
-										enabled: noRM.checked
-										visible: noRM.checked
-										onEnabledChanged: { if (!enabled) currentIndex = -1 }
-									}
-
-									DropDown {
-										name: "RMRowAnnotation"
-										title: qsTr("Row")
-										visible: yesRM.checked
-										enabled: yesRM.checked
-										values: rowSplitRM.columnsNames.length > 0
-												? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(rowSplitRM.columnsNames[0])
-												   ? repeatedMeasuresFactors.factorLevelMap[rowSplitRM.columnsNames[0]]
-												   : rowSplitRM.levels)
-												: []
-										addEmptyValue: groupValue.columnsNames.length === 0
-										placeholderText: qsTr("<No Value>")
-										onEnabledChanged: { if (!enabled) currentIndex = -1 }
-									}
-
-									DropDown {
-										name: "GridAnnotation"
-										label: qsTr("Grid")
-										values: gridVariablePlotBuilder.levels
-										enabled: noRM.checked
-										visible: noRM.checked
-										onEnabledChanged: { if (!enabled) currentIndex = -1 }
-									}
-
-									DropDown {
-										name: "RMGridAnnotation"
-										title: qsTr("Grid")
-										visible: yesRM.checked
-										enabled: yesRM.checked
-										values: gridVarRM.columnsNames.length > 0
-												? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(gridVarRM.columnsNames[0])
-												   ? repeatedMeasuresFactors.factorLevelMap[gridVarRM.columnsNames[0]]
-												   : gridVarRM.levels)
-												: []
-										addEmptyValue: groupValue.columnsNames.length === 0
-										placeholderText: qsTr("<No Value>")
-										onEnabledChanged: { if (!enabled) currentIndex = -1 }
-									}
-								}
-							}
-
-							Group {
-								title: qsTr("Appearance")
-								DoubleField {
-									name: "annotationSize"
-									label: qsTr("Size")
-									defaultValue: 5.5
-								}
-								TextField {
-									name: "colorText"
-									label: qsTr("Color")
-									placeholderText: qsTr("e.g. black, #ff5733")
-									defaultValue: "black"
-									fieldWidth: 60
-								}
-							}
-						}
+					TextField {
+						name: "newColorLabel"
+						label: qsTr("New label")
+						fieldWidth: 100
 					}
 				}
 			}
+		}
 
+		Section{
+			title: qsTr("Order of geometries")
 
+			/* key ↔︎ readable name list (one per line) */
+			info: qsTr(
+				"point: Point<br>"
+			  + "histogram: Histogram<br>"
+			  + "boxplot: Boxplot<br>"
+			  + "violin: Violin plot<br>"
+			  + "count_bar: Count bar<br>"
+			  + "count_dash: Count dash<br>"
+			  + "count_line: Count line<br>"
+			  + "count_area: Count area<br>"
+			  + "count_dot: Count dot<br>"
+			  + "count_value: Count value<br>"
+			  + "sum_bar: Sum bar<br>"
+			  + "sum_dash: Sum dash<br>"
+			  + "sum_line: Sum line<br>"
+			  + "sum_area: Sum area<br>"
+			  + "sum_dot: Sum dot<br>"
+			  + "sum_value: Sum value<br>"
+			  + "barstack: Bar stack<br>"
+			  + "areastack: Area stack<br>"
+			  + "mean_bar: Mean bar<br>"
+			  + "mean_dash: Mean dash<br>"
+			  + "mean_line: Mean line<br>"
+			  + "mean_area: Mean area<br>"
+			  + "mean_dot: Mean dot<br>"
+			  + "mean_value: Mean value<br>"
+			  + "median_bar: Median bar<br>"
+			  + "median_dash: Median dash<br>"
+			  + "median_line: Median line<br>"
+			  + "median_area: Median area<br>"
+			  + "median_dot: Median dot<br>"
+			  + "median_value: Median value<br>"
+			  + "range_errorbar: Range error bar<br>"
+			  + "sd_errorbar: SD error bar<br>"
+			  + "sem_errorbar: SEM error bar<br>"
+			  + "ci95_errorbar: 95% CI error bar<br>"
+			  + "range_ribbon: Range ribbon<br>"
+			  + "sd_ribbon: SD ribbon<br>"
+			  + "sem_ribbon: SEM ribbon<br>"
+			  + "ci95_ribbon: 95% CI ribbon<br>"
+			  + "curve_fit: Curve fit<br>"
+			  + "stat_ellipse: Stat ellipse<br>"
+			  + "rm_lines: RM lines<br>"
+			  + "reference_lines: Reference lines<br>"
+			  + "identity_line: Identity line<br>"
+			  + "point_labels: Point labels"
+			)
 
 			Label {
-				text: qsTr("Theme, colors, size, and legend")
+				text: qsTr(
+					"You can set the order of the added geometric/data layers here, similar to the example shown in the text field.\n"
+				  + "The order of the layers is defined from left to right—meaning the rightmost layer will be drawn on top."
+				)
 				wrapMode: Text.Wrap
 				color: "black"
-				font.bold: true
 			}
 
+			TextField {
+				label: qsTr("Layer order")
+				name: "layerOrder"
+				placeholderText: qsTr("point, boxplot")
+				fieldWidth: 300
+			}
+		}
 
-			Section {
-				title: qsTr("Theme and color")
 
-				/* section-level help */
-				info: qsTr("Choose an overall visual style and how colours are assigned. "
-						 + "<b>Theme</b> applies a preset look, while <b>Font base size</b> scales all text. "
-						 + "<b>Color settings</b> lets you map colour to a variable, pick a palette, or enter custom colours")
+		Label {
+			text: qsTr("Split and grid control")
+			wrapMode: Text.Wrap
+			color: "black"
+			font.bold: true
+		}
 
-				/* ────────────────── Theme & font size ────────────────── */
-				Group {
-					columns: 2
+		Section {
+			title: qsTr("Split control")
+
+			/* section-level help */
+			info: qsTr("Adjust how faceted panels share scales, axes and space. "
+					 + "<b>Scale and axis settings</b> decide whether panels use the same range, which axis lines are drawn and where labels appear. "
+					 + "<b>Layout settings</b> control panel sizes, the position of the highest-value table, optional marginal plots and custom axis titles")
+
+			GridLayout {
+				columns: 2
+				rowSpacing: 10
+				columnSpacing: 20
+				enabled: columnsvariableSplitPlotBuilder.count > 0 || colSplitRM.count > 0
+					  || rowsvariableSplitPlotBuilder.count > 0    || rowSplitRM.count > 0
+
+				/* ────────── Scale and axis settings ────────── */
+				Label { text: qsTr("Scale and axis settings") }
+
+				Column {
+					spacing: 10
 
 					DropDown {
-						name: "plotStyle"
-						label: qsTr("Theme")
-						values: ["JASP", "ggplotgray", "ggpubr", "PlotBuilder"]
-						indexDefaultValue: 0
+						name: "scales"
+						label: qsTr("Scale range")
+						info: qsTr("Choose whether facet panels share a common scale (<i>fixed</i>) or get individual ranges")
+						values: [
+							{ label: qsTr("shared across all facets"), value: "fixed" },
+							{ label: qsTr("vary across X"),            value: "free_x" },
+							{ label: qsTr("vary across Y"),            value: "free_y" },
+							{ label: qsTr("vary across both axes"),    value: "free" }
+						]
+						startValue: "fixed"
+					}
+
+					DropDown {
+						name: "axes"
+						label: qsTr("Show axis lines")
+						info: qsTr("Decide which facet panels display axis lines")
+						values: [
+							{ label: qsTr("only on outer panels"), value: "margins" },
+							{ label: qsTr("on all X axes"),        value: "all_x" },
+							{ label: qsTr("on all Y axes"),        value: "all_y" },
+							{ label: qsTr("on all axes"),          value: "all" }
+						]
+						startValue: "margins"
+					}
+
+					DropDown {
+						name: "axisLabels"
+						label: qsTr("Axis label visibility")
+						info: qsTr("Control which tick-label texts are shown")
+						values: [
+							{ label: qsTr("show on all axes"),        value: "all" },
+							{ label: qsTr("only on outer axes"),      value: "margins" },
+							{ label: qsTr("only on interior X axes"), value: "all_x" },
+							{ label: qsTr("only on interior Y axes"), value: "all_y" }
+						]
+						startValue: "all"
+					}
+				}
+
+				/* ────────── Layout settings ────────── */
+				Label { text: qsTr("Layout settings") }
+
+				Column {
+					spacing: 10
+
+					RadioButtonGroup {
+						id: asTableGroup
+						name: "asTable"
+						title: qsTr("Highest value at")
+						info: qsTr("Controls where the summary table of highest values is placed inside each facet")
+						radioButtonsOnSameRow: true
+
+						RadioButton {
+							value: "bottom-right"
+							label: qsTr("bottom right")
+							checked: true
+						}
+						RadioButton {
+							value: "top-right"
+							label: qsTr("top right")
+						}
+					}
+
+					DropDown {
+						name: "space"
+						label: qsTr("Panel size adjustment")
+						info: qsTr("Allow facet panels to stretch freely along X, Y or both axes")
+						values: [
+							{ label: qsTr("same size"),               value: "fixed" },
+							{ label: qsTr("free width (X)"),          value: "free_x" },
+							{ label: qsTr("free height (Y)"),         value: "free_y" },
+							{ label: qsTr("free width and height"),   value: "free" }
+						]
+						startValue: "fixed"
+					}
+
+					CheckBox {
+						id: marginsCheckBox
+						name: "margins"
+						label: qsTr("Include marginal plots")
+						info: qsTr("Adds aggregated rows/columns at the edges of the facet grid")
+						checked: false
+					}
+
+					/* custom axis titles for split layouts */
+					TextField {
+						name: "xAxisTitleSplit"
+						label: qsTr("X axis title")
+						placeholderText: qsTr("Enter a label for the X axis")
+					}
+					TextField {
+						name: "yAxisTitleSplit"
+						label: qsTr("Y axis title")
+						placeholderText: qsTr("Enter a label for the Y axis")
+					}
+				}
+			}
+		}
+
+
+		Section {
+			title: qsTr("Grid control")
+
+			/* section-level help */
+			info: qsTr("Arrange panels when a grid variable is mapped. "
+					 + "<b>Layout settings</b> set the facet grid’s rows, columns and where the highest-values table appears, "
+					 + "<b>Scales and strip settings</b> decide whether panels share axes and where the facet label strip is placed")
+
+			GridLayout {
+				enabled: gridVariablePlotBuilder.count > 0 || gridVarRM.count > 0
+				columns: 2
+				rowSpacing: 10
+				columnSpacing: 20
+
+				Label { text: qsTr("Layout settings") }
+
+				Column {
+					spacing: 10
+
+					DoubleField {
+						name: "ncolFacetWrap"
+						label: qsTr("Number of columns")
+						info: qsTr("Fixed number of facet columns; 0 lets the layout pick automatically")
+						defaultValue: gridVariablePlotBuilder.levels ? Math.floor(gridVariablePlotBuilder.levels / 2) + 1 : 0
 					}
 
 					DoubleField {
-						name: "baseFontSize"
-						label: qsTr("Font base size")
-						value: 18
+						name: "nrowFacetWrap"
+						label: qsTr("Number of rows")
+						info: qsTr("Fixed number of facet rows; 0 lets the layout pick automatically")
+						defaultValue: gridVariablePlotBuilder.levels ? Math.floor(gridVariablePlotBuilder.levels / 2) + 1 : 0
+					}
+
+					RadioButtonGroup {
+						name: "asTableFacetWrap"
+						title: qsTr("Highest value at")
+						info: qsTr("Choose the corner where the summary table of highest values is drawn")
+						radioButtonsOnSameRow: true
+
+						RadioButton {
+							value: "bottom-rightFacetWrap"
+							label: qsTr("bottom right")
+							checked: true
+						}
+						RadioButton {
+							value: "top-rightFacetWrap"
+							label: qsTr("top right")
+						}
 					}
 				}
 
-				/* ────────────────── Colour mapping and palettes ────────────────── */
-				Group {
-					title: qsTr("Color settings")
-					info: qsTr("Decide which variable drives colours and select a palette or provide custom hex/named colours")
-					columns: 1
+				Label { text: qsTr("Scales and strip settings") }
 
-					RadioButtonGroup {
-						name: "colorByGroup"
-						title: qsTr("Color by")
-						info: qsTr("Choose what determines element colours")
-						radioButtonsOnSameRow: true
-						columns: 4
+				Column {
+					spacing: 10
 
-						RadioButton {
-							value: "none"
-							label: qsTr("None")
-							info: qsTr("Uniform colors")
-							enabled: true
-							checked: !colorXRadio.checked && !colorYRadio.checked
-							onEnabledChanged: { if (!enabled && checked) checked = false }
-						}
-						RadioButton {
-							value: "grouping"
-							label: qsTr("Group variable")
-							info: qsTr("Coloring by Group variable")
-							enabled: variableColorPlotBuilder.count > 0 || groupVarRM.count > 0
-							checked: variableColorPlotBuilder.count > 0 || groupVarRM.count > 0
-							onEnabledChanged: { if (!enabled && checked) checked = false }
-						}
-						RadioButton {
-							id: colorXRadio
-							value: "x"
-							label: qsTr("X variable")
-							info: qsTr("Coloring by X variable")
-							enabled: (variableXPlotBuilder.count > 0 && variableColorPlotBuilder.count === 0) || (xVarRM.count > 0 && groupVarRM.count === 0)
-							checked: false
-							onEnabledChanged: { if (!enabled && checked) checked = false }
-						}
-						RadioButton {
-							id: colorYRadio
-							value: "y"
-							label: qsTr("Y variable")
-							info: qsTr("Coloring by Y variable")
-							enabled: (variableYPlotBuilder.count > 0 && variableColorPlotBuilder.count === 0) || (groupVarRM.count === 0)
-							checked: false
-							onEnabledChanged: { if (!enabled && checked) checked = false }
-						}
-						RadioButton {
-							value: "splitColumn"
-							info: qsTr("Apply separate colours in different splits")
-							label: qsTr("Split (column)")
-							enabled: columnsvariableSplitPlotBuilder.count > 0 || colSplitRM.count > 0
-							checked: false
-							onEnabledChanged: { if (!enabled && checked) checked = false }
-						}
-						RadioButton {
-							value: "splitRow"
-							label: qsTr("Split (rows)")
-							info: qsTr("Apply separate colours in different splits")
-							enabled: rowsvariableSplitPlotBuilder.count > 0 || rowSplitRM.count > 0
-							checked: false
-							onEnabledChanged: { if (!enabled && checked) checked = false }
-						}
+					DropDown {
+						name: "scalesFacetWrap"
+						label: qsTr("Scale range")
+						info: qsTr("Fixed panels share axes; free panels get independent X and/or Y scales")
+						values: [
+							{ label: qsTr("shared across all facets"), value: "fixed" },
+							{ label: qsTr("vary across X"),            value: "free_x" },
+							{ label: qsTr("vary across Y"),            value: "free_y" },
+							{ label: qsTr("vary across both axes"),    value: "free" }
+						]
+						startValue: "fixed"
 					}
 
 					DropDown {
-						name: "colorsAll"
-						label: qsTr("Color schemes")
-						indexDefaultValue: 0
+						name: "stripPosition"
+						label: qsTr("Strip position")
+						info: qsTr("Location of the facet label strip")
 						values: [
-							{ label: qsTr("JASP colors: jaspPalette"), value: "jaspPalette" },
-							{ label: qsTr("JASP colors: colorblind"), value: "colorblind" },
-							{ label: qsTr("JASP colors: colorblind2"), value: "colorblind2" },
-							{ label: qsTr("JASP colors: colorblind3"), value: "colorblind3" },
-							{ label: qsTr("JASP colors: sportsTeamsNBA"), value: "sportsTeamsNBA" },
-							{ label: qsTr("JASP colors: ggplot2"), value: "ggplot2" },
-							{ label: qsTr("JASP colors: grandBudapest"), value: "grandBudapest" },
-							{ label: qsTr("JASP colors: gray"), value: "gray" },
-							{ label: qsTr("JASP colors: blue"), value: "blue" },
-							{ label: qsTr("Discrete: Friendly"), value: "colors_discrete_friendly" },
-							{ label: qsTr("Discrete: Seaside"), value: "colors_discrete_seaside" },
-							{ label: qsTr("Discrete: Apple"), value: "colors_discrete_apple" },
-							{ label: qsTr("Discrete: Friendly Long"), value: "colors_discrete_friendly_long" },
-							{ label: qsTr("Discrete: Okabe Ito"), value: "colors_discrete_okabeito" },
-							{ label: qsTr("Discrete: IBM"), value: "colors_discrete_ibm" },
-							{ label: qsTr("Discrete: Metro"), value: "colors_discrete_metro" },
-							{ label: qsTr("Discrete: Candy"), value: "colors_discrete_candy" },
-							{ label: qsTr("Discrete: Alger"), value: "colors_discrete_alger" },
-							{ label: qsTr("Discrete: Rainbow"), value: "colors_discrete_rainbow" },
-							{ label: qsTr("Continuous: Viridis"), value: "colors_continuous_viridis" },
-							{ label: qsTr("Continuous: Magma"), value: "colors_continuous_magma" },
-							{ label: qsTr("Continuous: Inferno"), value: "colors_continuous_inferno" },
-							{ label: qsTr("Continuous: Plasma"), value: "colors_continuous_plasma" },
-							{ label: qsTr("Continuous: Cividis"), value: "colors_continuous_cividis" },
-							{ label: qsTr("Continuous: Rocket"), value: "colors_continuous_rocket" },
-							{ label: qsTr("Continuous: Mako"), value: "colors_continuous_mako" },
-							{ label: qsTr("Continuous: Turbo"), value: "colors_continuous_turbo" },
-							{ label: qsTr("Continuous: Blue Pink Yellow"), value: "colors_continuous_bluepinkyellow" },
-							{ label: qsTr("Diverging: Blue to Red"), value: "colors_diverging_blue2red" },
-							{ label: qsTr("Diverging: Blue to Brown"), value: "colors_diverging_blue2brown" },
-							{ label: qsTr("Diverging: BuRd"), value: "colors_diverging_BuRd" },
-							{ label: qsTr("Diverging: BuYlRd"), value: "colors_diverging_BuYlRd" },
-							{ label: qsTr("Diverging: Spectral"), value: "colors_diverging_spectral" },
-							{ label: qsTr("Diverging: Icefire"), value: "colors_diverging_icefire" }
+							{ label: qsTr("top"),    value: "top" },
+							{ label: qsTr("bottom"), value: "bottom" },
+							{ label: qsTr("left"),   value: "left" },
+							{ label: qsTr("right"),  value: "right" }
 						]
+						startValue: "top"
 					}
+				}
+			}
+		}
+
+
+		Label {
+			text: qsTr("P value and comparison lines")
+			wrapMode: Text.Wrap
+			color: "black"
+			font.bold: true
+		}
+
+		Section {
+
+			title: qsTr("P value brackets")
+			columns: 3
+
+			/* section-level help */
+			info: qsTr("Add brackets with P values to show pairwise significance.\n"
+					 + "Set colour, text size and vertical spacing, then list each comparison in the table below")
+
+			Label {
+				text: qsTr("Required: X AND Y-Axis Variables")
+				wrapMode: Text.Wrap
+				color: "black"
+			}
+
+			Group {
+				columns: 2
+
+				/* ── Text appearance ── */
+				Group {
+					columns: 1
+					info: qsTr("Colour and font size of the P-value text")
 
 					TextField {
-						name: "customColors"
-						label: qsTr("Custom colors")
-						info: qsTr("Here you can specify custom colors separated by commas")
-						placeholderText: qsTr("e.g. red, blue, #ff5733")
-						fieldWidth: 150
+						name: "labelcolor"
+						label: qsTr("P value color")
+						info: qsTr("Named or hex colour for the P value text")
+						fieldWidth: 70
+						defaultValue: "black"
+					}
+
+					DoubleField {
+						name: "labelSizePValue"
+						label: qsTr("P value size")
+						info: qsTr("Font size of the P value text")
+						defaultValue: 4.5
+					}
+				}
+
+				/* ── Vertical placement ── */
+				Group {
+					columns: 1
+					info: qsTr("Starting height and step between stacked brackets (data units)")
+
+					DoubleField {
+						name: "yPositionPValue"
+						label: qsTr("Y-Axis position of the first P value")
+						info: qsTr("Initial vertical position for the first bracket")
+						decimals: 2
+						fieldWidth: 70
+						value: 70
+					}
+
+					DoubleField {
+						name: "stepDistance"
+						label: qsTr("Step distance")
+						info: qsTr("Vertical gap between successive brackets")
+						decimals: 2
+						fieldWidth: 70
+						value: 0.15
 					}
 
 					Label {
-						text: qsTr("Note: For available colors, see %1this page%2")
-								.arg("<a href='https://r-charts.com/colors/' style='color: blue; text-decoration: underline;'>")
-								.arg("</a>")
+						text: qsTr("Note: If custom Y-Axis limits are set, the starting\n"
+								   + "position for the P value must fall within the defined interval")
 						wrapMode: Text.Wrap
-						textFormat: Text.RichText
-						MouseArea {
-							anchors.fill: parent
-							onClicked: { Qt.openUrlExternally("https://r-charts.com/colors/") }
+						color: "black"
+					}
+				}
+			}
+
+			ComponentsList {
+				name: "pairwiseComparisons"
+				title: qsTr("Pairwise comparisons table")
+				id: pairwiseComparisons
+				addItemManually: true
+				minimumItems: 0
+				maximumItems: -1
+
+				enabled: (
+							 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+						  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+						 )
+
+				onEnabledChanged: {
+					if (!enabled) {
+						for (var i = pairwiseComparisons.count - 1; i >= 0; --i)
+							pairwiseComparisons.removeItem(i)
+					}
+				}
+
+				rowComponent: Row {
+
+					Group {
+						title: qsTr("Bracket ") + (rowIndex + 1)
+						columns: 3
+
+						/* Compared groups ------------------------------------ */
+						Group {
+							title: qsTr("Compared groups")
+							info: qsTr("Labels of the two groups being compared")
+
+							TextField {
+								name: "group1"
+								label: qsTr("Group 1")
+								fieldWidth: 60
+							}
+
+							TextField {
+								name: "group2"
+								label: qsTr("Group 2")
+								fieldWidth: 60
+							}
+						}
+
+						/* P value & bracket style ---------------------------- */
+						Group {
+							title: qsTr("P value and brackets")
+							info: qsTr("Enter the P value (e.g. 0.03) or a significance symbol (*, **, ***). "
+									 + "<b>Tip length</b> is the size of the bracket tips; "
+									 + "<b>Bracket size</b> is the horizontal width")
+
+							TextField {
+								name: "pAdj"
+								label: qsTr("P value")
+								fieldWidth: 60
+								value: "* or 0.001"
+							}
+
+							DoubleField {
+								name: "tipLengthPValue"
+								label: qsTr("Tip length")
+								decimals: 2
+								fieldWidth: 70
+								value: 0.03
+							}
+
+							DoubleField {
+								name: "bracketSizePValue"
+								label: qsTr("Bracket size")
+								decimals: 2
+								fieldWidth: 70
+								value: 0.3
+							}
+						}
+
+						/* Facet position ------------------------------------- */
+						Group {
+							title: qsTr("Position")
+							columns: 2
+							info: qsTr("Select the facet (group/column/row/grid) where the bracket should appear")
+
+							/* group selectors */
+							DropDown { name: "GroupPValue";  label: qsTr("Group");  values: variableColorPlotBuilder.levels; visible: noRM.checked; enabled: noRM.checked; onEnabledChanged: { if (!enabled) currentIndex = -1 } }
+							DropDown { name: "RMGroupPValue"; label: qsTr("Group"); visible: yesRM.checked; enabled: yesRM.checked;
+									   values: groupVarRM.columnsNames.length > 0
+											   ? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(groupVarRM.columnsNames[0])
+												  ? repeatedMeasuresFactors.factorLevelMap[groupVarRM.columnsNames[0]]
+												  : groupVarRM.levels)
+											   : [];
+									   addEmptyValue: groupValue.columnsNames.length === 0; placeholderText: qsTr("<No Value>");
+									   onEnabledChanged: { if (!enabled) currentIndex = -1 } }
+
+							/* column selectors */
+							DropDown { name: "ColumnPValue";  label: qsTr("Column"); values: columnsvariableSplitPlotBuilder.levels; visible: noRM.checked; enabled: noRM.checked; onEnabledChanged: { if (!enabled) currentIndex = -1 } }
+							DropDown { name: "RMColumnPValue"; label: qsTr("Column"); visible: yesRM.checked; enabled: yesRM.checked;
+									   values: colSplitRM.columnsNames.length > 0
+											   ? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(colSplitRM.columnsNames[0])
+												  ? repeatedMeasuresFactors.factorLevelMap[colSplitRM.columnsNames[0]]
+												  : colSplitRM.levels)
+											   : [];
+									   addEmptyValue: groupValue.columnsNames.length === 0; placeholderText: qsTr("<No Value>");
+									   onEnabledChanged: { if (!enabled) currentIndex = -1 } }
+
+							/* row selectors */
+							DropDown { name: "RowPValue";  label: qsTr("Row"); values: rowsvariableSplitPlotBuilder.levels; visible: noRM.checked; enabled: noRM.checked; onEnabledChanged: { if (!enabled) currentIndex = -1 } }
+							DropDown { name: "RMRowPValue"; label: qsTr("Row"); visible: yesRM.checked; enabled: yesRM.checked;
+									   values: rowSplitRM.columnsNames.length > 0
+											   ? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(rowSplitRM.columnsNames[0])
+												  ? repeatedMeasuresFactors.factorLevelMap[rowSplitRM.columnsNames[0]]
+												  : rowSplitRM.levels)
+											   : [];
+									   addEmptyValue: groupValue.columnsNames.length === 0; placeholderText: qsTr("<No Value>");
+									   onEnabledChanged: { if (!enabled) currentIndex = -1 } }
+
+							/* grid selectors */
+							DropDown { name: "GridPValue";  label: qsTr("Grid"); values: gridVariablePlotBuilder.levels; visible: noRM.checked; enabled: noRM.checked; onEnabledChanged: { if (!enabled) currentIndex = -1 } }
+							DropDown { name: "RMGridPValue"; label: qsTr("Grid"); visible: yesRM.checked; enabled: yesRM.checked;
+									   values: gridVarRM.columnsNames.length > 0
+											   ? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(gridVarRM.columnsNames[0])
+												  ? repeatedMeasuresFactors.factorLevelMap[gridVarRM.columnsNames[0]]
+												  : gridVarRM.levels)
+											   : [];
+									   addEmptyValue: groupValue.columnsNames.length === 0; placeholderText: qsTr("<No Value>");
+									   onEnabledChanged: { if (!enabled) currentIndex = -1 } }
 						}
 					}
 				}
 			}
+		}
 
 
-			Section {
-				title: qsTr("Size, margins and plot orientation")
-				columns: 1
-
-				/* section-level help */
-				info: qsTr("Control the canvas dimensions and whitespace. "
-						 + "<b>Plot size</b> sets the pixel width × height, "
-						 + "<b>Axis padding</b> adds proportional space inside the axes, "
-						 + "<b>Margins</b> add outer whitespace, and "
-						 + "<b>Plot orientation</b> can flip X and Y")
-
-				Group {
-					title: qsTr("Plot size")
-					info: qsTr("Width and height of the exported figure in pixels")
-					columns: 2
-
-					DoubleField {
-						id: plotWidth
-						name: "widthPlotBuilder"
-						label: qsTr("Width (px)")
-						defaultValue: 380
-						fieldWidth: 50
-					}
-
-					DoubleField {
-						id: plotHeight
-						name: "heightPlotBuilder"
-						label: qsTr("Height (px)")
-						defaultValue: 300
-						fieldWidth: 50
-					}
-				}
-
-				Group {
-					title: qsTr("Axis padding")
-					info: qsTr("Fraction of the data range to leave empty inside each axis (0 – 1)")
-					columns: 4
-
-					DoubleField { name: "YPaddingSecond"; label: qsTr("Top");    value: 0.05 }
-					DoubleField { name: "YPaddingFirst";  label: qsTr("Bottom"); value: 0.04 }
-					DoubleField { name: "XPaddingFirst";  label: qsTr("Left");   value: 0.05 }
-					DoubleField { name: "XPaddingSecond"; label: qsTr("Right");  value: 0.05 }
-				}
-
-				Group {
-					title: qsTr("Margins")
-					info: qsTr("Outer whitespace around the plot (pts)")
-					columns: 4
-
-					DoubleField { name: "topMargin";    label: qsTr("Top");    value: 10 }
-					DoubleField { name: "bottomMargin"; label: qsTr("Bottom"); value: 10 }
-					DoubleField { name: "leftMargin";   label: qsTr("Left");   value: 10 }
-					DoubleField { name: "rightMargin";  label: qsTr("Right");  value: 10 }
-				}
-
-				Group {
-					title: qsTr("Plot orientation")
-					info: qsTr("Flip swaps the X and Y axes")
-					CheckBox { name: "flipPlot"; label: qsTr("Flip plot") }
-				}
-			}
-
-
-			// -------------------------------------------------------------------
-			// Edit style and colors
-			// -------------------------------------------------------------------
-			Section {
-				title: qsTr("Legend")
-
-				info: qsTr("Control where the legend appears and what it shows. "
-						 + "Use <b>Position</b> to dock the legend or hide it. "
-						 + "<b>Remove title</b> hides the legend heading")
-
-				Group {
-					columns: 2
-
-					DropDown {
-						name: "legendPosistionPlotBuilder"
-						label: qsTr("Position")
-						id: legendPosistionPlotBuilder
-						indexDefaultValue: 0
-						fieldWidth: 150
-						values: [
-							{ label: qsTr("Right"),      value: "right" },
-							{ label: qsTr("Left"),       value: "left" },
-							{ label: qsTr("Bottom"),     value: "bottom" },
-							{ label: qsTr("Top"),        value: "top" },
-							{ label: qsTr("No legend"),  value: "none" }
-						]
-					}
-
-					CheckBox {
-						name: "removeLegendTitle"
-						label: qsTr("Remove title")
-					}
-				}
-
-				ComponentsList {
-					name: "colorLabelRenamer"
-					title: qsTr("Rename labels")
-					info: qsTr("Edit the text of individual legend entries")
-					addItemManually: true
-					minimumItems: 0
-
-					rowComponent: Row {
-						TextField {
-							name: "originalColorLabel"
-							label: qsTr("Original label")
-							fieldWidth: 100
-						}
-						TextField {
-							name: "newColorLabel"
-							label: qsTr("New label")
-							fieldWidth: 100
-						}
-					}
-				}
-			}
-
-			Section{
-				title: qsTr("Order of geometries")
-
-				/* key ↔︎ readable name list (one per line) */
-				info: qsTr(
-					"point: Point<br>"
-				  + "histogram: Histogram<br>"
-				  + "boxplot: Boxplot<br>"
-				  + "violin: Violin plot<br>"
-				  + "count_bar: Count bar<br>"
-				  + "count_dash: Count dash<br>"
-				  + "count_line: Count line<br>"
-				  + "count_area: Count area<br>"
-				  + "count_dot: Count dot<br>"
-				  + "count_value: Count value<br>"
-				  + "sum_bar: Sum bar<br>"
-				  + "sum_dash: Sum dash<br>"
-				  + "sum_line: Sum line<br>"
-				  + "sum_area: Sum area<br>"
-				  + "sum_dot: Sum dot<br>"
-				  + "sum_value: Sum value<br>"
-				  + "barstack: Bar stack<br>"
-				  + "areastack: Area stack<br>"
-				  + "mean_bar: Mean bar<br>"
-				  + "mean_dash: Mean dash<br>"
-				  + "mean_line: Mean line<br>"
-				  + "mean_area: Mean area<br>"
-				  + "mean_dot: Mean dot<br>"
-				  + "mean_value: Mean value<br>"
-				  + "median_bar: Median bar<br>"
-				  + "median_dash: Median dash<br>"
-				  + "median_line: Median line<br>"
-				  + "median_area: Median area<br>"
-				  + "median_dot: Median dot<br>"
-				  + "median_value: Median value<br>"
-				  + "range_errorbar: Range error bar<br>"
-				  + "sd_errorbar: SD error bar<br>"
-				  + "sem_errorbar: SEM error bar<br>"
-				  + "ci95_errorbar: 95% CI error bar<br>"
-				  + "range_ribbon: Range ribbon<br>"
-				  + "sd_ribbon: SD ribbon<br>"
-				  + "sem_ribbon: SEM ribbon<br>"
-				  + "ci95_ribbon: 95% CI ribbon<br>"
-				  + "curve_fit: Curve fit<br>"
-				  + "stat_ellipse: Stat ellipse<br>"
-				  + "rm_lines: RM lines<br>"
-				  + "reference_lines: Reference lines<br>"
-				  + "identity_line: Identity line<br>"
-				  + "point_labels: Point labels"
-				)
-
-				Label {
-					text: qsTr(
-						"You can set the order of the added geometric/data layers here, similar to the example shown in the text field.\n"
-					  + "The order of the layers is defined from left to right—meaning the rightmost layer will be drawn on top."
-					)
-					wrapMode: Text.Wrap
-					color: "black"
-				}
-
-				TextField {
-					label: qsTr("Layer order")
-					name: "layerOrder"
-					placeholderText: qsTr("point, boxplot")
-					fieldWidth: 300
-				}
-			}
-
+		Section {
+			title: qsTr("Custom comparison lines")
+			columns: 4
+			/* section-level help */
+			info: qsTr("Draw manual comparison lines (e.g., <b>min–max bars</b> or custom contrasts) with optional text labels")
 
 			Label {
-				text: qsTr("Split and grid control")
+				text: qsTr("Required: X AND Y-Axis Variables")
 				wrapMode: Text.Wrap
 				color: "black"
-				font.bold: true
 			}
-
-			Section {
-				title: qsTr("Split control")
-
-				/* section-level help */
-				info: qsTr("Adjust how faceted panels share scales, axes and space. "
-						 + "<b>Scale and axis settings</b> decide whether panels use the same range, which axis lines are drawn and where labels appear. "
-						 + "<b>Layout settings</b> control panel sizes, the position of the highest-value table, optional marginal plots and custom axis titles")
-
-				GridLayout {
-					columns: 2
-					rowSpacing: 10
-					columnSpacing: 20
-					enabled: columnsvariableSplitPlotBuilder.count > 0 || colSplitRM.count > 0
-						  || rowsvariableSplitPlotBuilder.count > 0    || rowSplitRM.count > 0
-
-					/* ────────── Scale and axis settings ────────── */
-					Label { text: qsTr("Scale and axis settings") }
-
-					Column {
-						spacing: 10
-
-						DropDown {
-							name: "scales"
-							label: qsTr("Scale range")
-							info: qsTr("Choose whether facet panels share a common scale (<i>fixed</i>) or get individual ranges")
-							values: [
-								{ label: qsTr("shared across all facets"), value: "fixed" },
-								{ label: qsTr("vary across X"),            value: "free_x" },
-								{ label: qsTr("vary across Y"),            value: "free_y" },
-								{ label: qsTr("vary across both axes"),    value: "free" }
-							]
-							startValue: "fixed"
-						}
-
-						DropDown {
-							name: "axes"
-							label: qsTr("Show axis lines")
-							info: qsTr("Decide which facet panels display axis lines")
-							values: [
-								{ label: qsTr("only on outer panels"), value: "margins" },
-								{ label: qsTr("on all X axes"),        value: "all_x" },
-								{ label: qsTr("on all Y axes"),        value: "all_y" },
-								{ label: qsTr("on all axes"),          value: "all" }
-							]
-							startValue: "margins"
-						}
-
-						DropDown {
-							name: "axisLabels"
-							label: qsTr("Axis label visibility")
-							info: qsTr("Control which tick-label texts are shown")
-							values: [
-								{ label: qsTr("show on all axes"),        value: "all" },
-								{ label: qsTr("only on outer axes"),      value: "margins" },
-								{ label: qsTr("only on interior X axes"), value: "all_x" },
-								{ label: qsTr("only on interior Y axes"), value: "all_y" }
-							]
-							startValue: "all"
-						}
-					}
-
-					/* ────────── Layout settings ────────── */
-					Label { text: qsTr("Layout settings") }
-
-					Column {
-						spacing: 10
-
-						RadioButtonGroup {
-							id: asTableGroup
-							name: "asTable"
-							title: qsTr("Highest value at")
-							info: qsTr("Controls where the summary table of highest values is placed inside each facet")
-							radioButtonsOnSameRow: true
-
-							RadioButton {
-								value: "bottom-right"
-								label: qsTr("bottom right")
-								checked: true
-							}
-							RadioButton {
-								value: "top-right"
-								label: qsTr("top right")
-							}
-						}
-
-						DropDown {
-							name: "space"
-							label: qsTr("Panel size adjustment")
-							info: qsTr("Allow facet panels to stretch freely along X, Y or both axes")
-							values: [
-								{ label: qsTr("same size"),               value: "fixed" },
-								{ label: qsTr("free width (X)"),          value: "free_x" },
-								{ label: qsTr("free height (Y)"),         value: "free_y" },
-								{ label: qsTr("free width and height"),   value: "free" }
-							]
-							startValue: "fixed"
-						}
-
-						CheckBox {
-							id: marginsCheckBox
-							name: "margins"
-							label: qsTr("Include marginal plots")
-							info: qsTr("Adds aggregated rows/columns at the edges of the facet grid")
-							checked: false
-						}
-
-						/* custom axis titles for split layouts */
-						TextField {
-							name: "xAxisTitleSplit"
-							label: qsTr("X axis title")
-							placeholderText: qsTr("Enter a label for the X axis")
-						}
-						TextField {
-							name: "yAxisTitleSplit"
-							label: qsTr("Y axis title")
-							placeholderText: qsTr("Enter a label for the Y axis")
-						}
-					}
-				}
-			}
-
-
-			Section {
-				title: qsTr("Grid control")
-
-				/* section-level help */
-				info: qsTr("Arrange panels when a grid variable is mapped. "
-						 + "<b>Layout settings</b> set the facet grid’s rows, columns and where the highest-values table appears, "
-						 + "<b>Scales and strip settings</b> decide whether panels share axes and where the facet label strip is placed")
-
-				GridLayout {
-					enabled: gridVariablePlotBuilder.count > 0 || gridVarRM.count > 0
-					columns: 2
-					rowSpacing: 10
-					columnSpacing: 20
-
-					Label { text: qsTr("Layout settings") }
-
-					Column {
-						spacing: 10
-
-						DoubleField {
-							name: "ncolFacetWrap"
-							label: qsTr("Number of columns")
-							info: qsTr("Fixed number of facet columns; 0 lets the layout pick automatically")
-							defaultValue: gridVariablePlotBuilder.levels ? Math.floor(gridVariablePlotBuilder.levels / 2) + 1 : 0
-						}
-
-						DoubleField {
-							name: "nrowFacetWrap"
-							label: qsTr("Number of rows")
-							info: qsTr("Fixed number of facet rows; 0 lets the layout pick automatically")
-							defaultValue: gridVariablePlotBuilder.levels ? Math.floor(gridVariablePlotBuilder.levels / 2) + 1 : 0
-						}
-
-						RadioButtonGroup {
-							name: "asTableFacetWrap"
-							title: qsTr("Highest value at")
-							info: qsTr("Choose the corner where the summary table of highest values is drawn")
-							radioButtonsOnSameRow: true
-
-							RadioButton {
-								value: "bottom-rightFacetWrap"
-								label: qsTr("bottom right")
-								checked: true
-							}
-							RadioButton {
-								value: "top-rightFacetWrap"
-								label: qsTr("top right")
-							}
-						}
-					}
-
-					Label { text: qsTr("Scales and strip settings") }
-
-					Column {
-						spacing: 10
-
-						DropDown {
-							name: "scalesFacetWrap"
-							label: qsTr("Scale range")
-							info: qsTr("Fixed panels share axes; free panels get independent X and/or Y scales")
-							values: [
-								{ label: qsTr("shared across all facets"), value: "fixed" },
-								{ label: qsTr("vary across X"),            value: "free_x" },
-								{ label: qsTr("vary across Y"),            value: "free_y" },
-								{ label: qsTr("vary across both axes"),    value: "free" }
-							]
-							startValue: "fixed"
-						}
-
-						DropDown {
-							name: "stripPosition"
-							label: qsTr("Strip position")
-							info: qsTr("Location of the facet label strip")
-							values: [
-								{ label: qsTr("top"),    value: "top" },
-								{ label: qsTr("bottom"), value: "bottom" },
-								{ label: qsTr("left"),   value: "left" },
-								{ label: qsTr("right"),  value: "right" }
-							]
-							startValue: "top"
-						}
-					}
-				}
-			}
-
 
 			Label {
-				text: qsTr("P value and comparison lines")
+				text: qsTr("Note: If custom Y-Axis limits are set, the starting\n"
+						   + "position for the Y-Axis start and end values must fall within the defined interval")
 				wrapMode: Text.Wrap
 				color: "black"
-				font.bold: true
 			}
 
-			Section {
+			ComponentsList {
+				name: "annotationLineList"
+				id: annotationLineList
+				title: qsTr("Add annotation lines")
+				addItemManually: true
+				minimumItems: 0
 
-				title: qsTr("P value brackets")
-				columns: 3
+				enabled: (
+							 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+						  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+						 )
 
-				/* section-level help */
-				info: qsTr("Add brackets with P values to show pairwise significance.\n"
-						 + "Set colour, text size and vertical spacing, then list each comparison in the table below")
-
-				Label {
-					text: qsTr("Required: X AND Y-Axis Variables")
-					wrapMode: Text.Wrap
-					color: "black"
+				onEnabledChanged: {
+					if (!enabled) {
+						for (var i = annotationLineList.count - 1; i >= 0; --i)
+							annotationLineList.removeItem(i)
+					}
 				}
 
-				Group {
-					columns: 2
+				rowComponent: Row {
 
-					/* ── Text appearance ── */
 					Group {
-						columns: 1
-						info: qsTr("Colour and font size of the P-value text")
+						columns: 4
+						title: qsTr("Line ") + (rowIndex + 1)
+						info: qsTr("Define one comparison line with optional label, coordinates and appearance")
 
-						TextField {
-							name: "labelcolor"
-							label: qsTr("P value color")
-							info: qsTr("Named or hex colour for the P value text")
-							fieldWidth: 70
-							defaultValue: "black"
-						}
-
-						DoubleField {
-							name: "labelSizePValue"
-							label: qsTr("P value size")
-							info: qsTr("Font size of the P value text")
-							defaultValue: 4.5
-						}
-					}
-
-					/* ── Vertical placement ── */
-					Group {
-						columns: 1
-						info: qsTr("Starting height and step between stacked brackets (data units)")
-
-						DoubleField {
-							name: "yPositionPValue"
-							label: qsTr("Y-Axis position of the first P value")
-							info: qsTr("Initial vertical position for the first bracket")
-							decimals: 2
-							fieldWidth: 70
-							value: 70
-						}
-
-						DoubleField {
-							name: "stepDistance"
-							label: qsTr("Step distance")
-							info: qsTr("Vertical gap between successive brackets")
-							decimals: 2
-							fieldWidth: 70
-							value: 0.15
-						}
-
-						Label {
-							text: qsTr("Note: If custom Y-Axis limits are set, the starting\n"
-									   + "position for the P value must fall within the defined interval")
-							wrapMode: Text.Wrap
-							color: "black"
-						}
-					}
-				}
-
-				ComponentsList {
-					name: "pairwiseComparisons"
-					title: qsTr("Pairwise comparisons table")
-					id: pairwiseComparisons
-					addItemManually: true
-					minimumItems: 0
-					maximumItems: -1
-
-					enabled: (
-								 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-							  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-							 )
-
-					onEnabledChanged: {
-						if (!enabled) {
-							for (var i = pairwiseComparisons.count - 1; i >= 0; --i)
-								pairwiseComparisons.removeItem(i)
-						}
-					}
-
-					rowComponent: Row {
-
+						/* ── Label text ── */
 						Group {
-							title: qsTr("Bracket ") + (rowIndex + 1)
-							columns: 3
-
-							/* Compared groups ------------------------------------ */
-							Group {
-								title: qsTr("Compared groups")
-								info: qsTr("Labels of the two groups being compared")
-
-								TextField {
-									name: "group1"
-									label: qsTr("Group 1")
-									fieldWidth: 60
-								}
-
-								TextField {
-									name: "group2"
-									label: qsTr("Group 2")
-									fieldWidth: 60
-								}
-							}
-
-							/* P value & bracket style ---------------------------- */
-							Group {
-								title: qsTr("P value and brackets")
-								info: qsTr("Enter the P value (e.g. 0.03) or a significance symbol (*, **, ***). "
-										 + "<b>Tip length</b> is the size of the bracket tips; "
-										 + "<b>Bracket size</b> is the horizontal width")
-
-								TextField {
-									name: "pAdj"
-									label: qsTr("P value")
-									fieldWidth: 60
-									value: "* or 0.001"
-								}
-
-								DoubleField {
-									name: "tipLengthPValue"
-									label: qsTr("Tip length")
-									decimals: 2
-									fieldWidth: 70
-									value: 0.03
-								}
-
-								DoubleField {
-									name: "bracketSizePValue"
-									label: qsTr("Bracket size")
-									decimals: 2
-									fieldWidth: 70
-									value: 0.3
-								}
-							}
-
-							/* Facet position ------------------------------------- */
-							Group {
-								title: qsTr("Position")
-								columns: 2
-								info: qsTr("Select the facet (group/column/row/grid) where the bracket should appear")
-
-								/* group selectors */
-								DropDown { name: "GroupPValue";  label: qsTr("Group");  values: variableColorPlotBuilder.levels; visible: noRM.checked; enabled: noRM.checked; onEnabledChanged: { if (!enabled) currentIndex = -1 } }
-								DropDown { name: "RMGroupPValue"; label: qsTr("Group"); visible: yesRM.checked; enabled: yesRM.checked;
-										   values: groupVarRM.columnsNames.length > 0
-												   ? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(groupVarRM.columnsNames[0])
-													  ? repeatedMeasuresFactors.factorLevelMap[groupVarRM.columnsNames[0]]
-													  : groupVarRM.levels)
-												   : [];
-										   addEmptyValue: groupValue.columnsNames.length === 0; placeholderText: qsTr("<No Value>");
-										   onEnabledChanged: { if (!enabled) currentIndex = -1 } }
-
-								/* column selectors */
-								DropDown { name: "ColumnPValue";  label: qsTr("Column"); values: columnsvariableSplitPlotBuilder.levels; visible: noRM.checked; enabled: noRM.checked; onEnabledChanged: { if (!enabled) currentIndex = -1 } }
-								DropDown { name: "RMColumnPValue"; label: qsTr("Column"); visible: yesRM.checked; enabled: yesRM.checked;
-										   values: colSplitRM.columnsNames.length > 0
-												   ? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(colSplitRM.columnsNames[0])
-													  ? repeatedMeasuresFactors.factorLevelMap[colSplitRM.columnsNames[0]]
-													  : colSplitRM.levels)
-												   : [];
-										   addEmptyValue: groupValue.columnsNames.length === 0; placeholderText: qsTr("<No Value>");
-										   onEnabledChanged: { if (!enabled) currentIndex = -1 } }
-
-								/* row selectors */
-								DropDown { name: "RowPValue";  label: qsTr("Row"); values: rowsvariableSplitPlotBuilder.levels; visible: noRM.checked; enabled: noRM.checked; onEnabledChanged: { if (!enabled) currentIndex = -1 } }
-								DropDown { name: "RMRowPValue"; label: qsTr("Row"); visible: yesRM.checked; enabled: yesRM.checked;
-										   values: rowSplitRM.columnsNames.length > 0
-												   ? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(rowSplitRM.columnsNames[0])
-													  ? repeatedMeasuresFactors.factorLevelMap[rowSplitRM.columnsNames[0]]
-													  : rowSplitRM.levels)
-												   : [];
-										   addEmptyValue: groupValue.columnsNames.length === 0; placeholderText: qsTr("<No Value>");
-										   onEnabledChanged: { if (!enabled) currentIndex = -1 } }
-
-								/* grid selectors */
-								DropDown { name: "GridPValue";  label: qsTr("Grid"); values: gridVariablePlotBuilder.levels; visible: noRM.checked; enabled: noRM.checked; onEnabledChanged: { if (!enabled) currentIndex = -1 } }
-								DropDown { name: "RMGridPValue"; label: qsTr("Grid"); visible: yesRM.checked; enabled: yesRM.checked;
-										   values: gridVarRM.columnsNames.length > 0
-												   ? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(gridVarRM.columnsNames[0])
-													  ? repeatedMeasuresFactors.factorLevelMap[gridVarRM.columnsNames[0]]
-													  : gridVarRM.levels)
-												   : [];
-										   addEmptyValue: groupValue.columnsNames.length === 0; placeholderText: qsTr("<No Value>");
-										   onEnabledChanged: { if (!enabled) currentIndex = -1 } }
+							title: qsTr("Label")
+							TextField {
+								name: "textAnnotationline"
+								label: qsTr("Label")
+								info: qsTr("Text shown near the line (leave empty for no label)")
+								fieldWidth: 60
 							}
 						}
-					}
-				}
-			}
 
-
-			Section {
-				title: qsTr("Custom comparison lines")
-				columns: 4
-				/* section-level help */
-				info: qsTr("Draw manual comparison lines (e.g., **min–max bars** or custom contrasts) with optional text labels")
-
-				Label {
-					text: qsTr("Required: X AND Y-Axis Variables")
-					wrapMode: Text.Wrap
-					color: "black"
-				}
-
-				Label {
-					text: qsTr("Note: If custom Y-Axis limits are set, the starting\n"
-							   + "position for the Y-Axis start and end values must fall within the defined interval")
-					wrapMode: Text.Wrap
-					color: "black"
-				}
-
-				ComponentsList {
-					name: "annotationLineList"
-					id: annotationLineList
-					title: qsTr("Add annotation lines")
-					addItemManually: true
-					minimumItems: 0
-
-					enabled: (
-								 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-							  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-							 )
-
-					onEnabledChanged: {
-						if (!enabled) {
-							for (var i = annotationLineList.count - 1; i >= 0; --i)
-								annotationLineList.removeItem(i)
-						}
-					}
-
-					rowComponent: Row {
-
+						/* ── Position ── */
 						Group {
+							title: qsTr("Position")
 							columns: 4
-							title: qsTr("Line ") + (rowIndex + 1)
-							info: qsTr("Define one comparison line with optional label, coordinates and appearance")
+							info: qsTr("Start/end coordinates and facet location")
 
-							/* ── Label text ── */
 							Group {
-								title: qsTr("Label")
-								TextField {
-									name: "textAnnotationline"
-									label: qsTr("Label")
-									info: qsTr("Text shown near the line (leave empty for no label)")
-									fieldWidth: 60
-								}
+								DoubleField { name: "xAnnotation";  label: qsTr("X-Axis start"); info: qsTr("Line start on X axis") }
+								DoubleField { name: "xendAnnotation"; label: qsTr("X-Axis end");  info: qsTr("Line end on X axis") }
+							}
+							Group {
+								DoubleField { name: "yAnnotation";  label: qsTr("Y-Axis start"); info: qsTr("Line start on Y axis") }
+								DoubleField { name: "yendAnnotation"; label: qsTr("Y-Axis end"); info: qsTr("Line end on Y axis") }
 							}
 
-							/* ── Position ── */
-							Group {
-								title: qsTr("Position")
-								columns: 4
-								info: qsTr("Start/end coordinates and facet location")
+							Group {columns: 1
 
-								Group {
-									DoubleField { name: "xAnnotation";  label: qsTr("X-Axis start"); info: qsTr("Line start on X axis") }
-									DoubleField { name: "xendAnnotation"; label: qsTr("X-Axis end");  info: qsTr("Line end on X axis") }
-								}
-								Group {
-									DoubleField { name: "yAnnotation";  label: qsTr("Y-Axis start"); info: qsTr("Line start on Y axis") }
-									DoubleField { name: "yendAnnotation"; label: qsTr("Y-Axis end"); info: qsTr("Line end on Y axis") }
-								}
+								DropDown { name: "ColumnAnnotationCompLine"; label: qsTr("Column"); values: columnsvariableSplitPlotBuilder.levels;
+										   visible: noRM.checked; enabled: noRM.checked;
+										   info: qsTr("Facet column (for split layouts)"); onEnabledChanged: { if (!enabled) currentIndex = -1 } }
+								DropDown { name: "RowAnnotationCompLine";    label: qsTr("Row");    values: rowsvariableSplitPlotBuilder.levels;
+										   visible: noRM.checked; enabled: noRM.checked;
+										   info: qsTr("Facet row (for split layouts)");    onEnabledChanged: { if (!enabled) currentIndex = -1 } }
+								DropDown { name: "GridAnnotationCompLine";   label: qsTr("Grid");   values: gridVariablePlotBuilder.levels;
+										   visible: noRM.checked; enabled: noRM.checked;
+										   info: qsTr("Facet grid cell");                   onEnabledChanged: { if (!enabled) currentIndex = -1 } }
 
-								Group {columns: 1
+								/* facet selectors – RM */
+								DropDown { name: "RMColumnCompLine"; label: qsTr("Column"); visible: yesRM.checked; enabled: yesRM.checked;
+										   info: qsTr("Facet column (RM)"); values: colSplitRM.columnsNames.length > 0
+													  ? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(colSplitRM.columnsNames[0])
+														 ? repeatedMeasuresFactors.factorLevelMap[colSplitRM.columnsNames[0]]
+														 : colSplitRM.levels)
+													  : [];
+										   addEmptyValue: groupValue.columnsNames.length === 0; placeholderText: qsTr("<No Value>");
+										   onEnabledChanged: { if (!enabled) currentIndex = -1 } }
 
-									DropDown { name: "ColumnAnnotationCompLine"; label: qsTr("Column"); values: columnsvariableSplitPlotBuilder.levels;
-											   visible: noRM.checked; enabled: noRM.checked;
-											   info: qsTr("Facet column (for split layouts)"); onEnabledChanged: { if (!enabled) currentIndex = -1 } }
-									DropDown { name: "RowAnnotationCompLine";    label: qsTr("Row");    values: rowsvariableSplitPlotBuilder.levels;
-											   visible: noRM.checked; enabled: noRM.checked;
-											   info: qsTr("Facet row (for split layouts)");    onEnabledChanged: { if (!enabled) currentIndex = -1 } }
-									DropDown { name: "GridAnnotationCompLine";   label: qsTr("Grid");   values: gridVariablePlotBuilder.levels;
-											   visible: noRM.checked; enabled: noRM.checked;
-											   info: qsTr("Facet grid cell");                   onEnabledChanged: { if (!enabled) currentIndex = -1 } }
+								DropDown { name: "RMRowCompLine"; label: qsTr("Row"); visible: yesRM.checked; enabled: yesRM.checked;
+										   info: qsTr("Facet row (RM)"); values: rowSplitRM.columnsNames.length > 0
+													  ? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(rowSplitRM.columnsNames[0])
+														 ? repeatedMeasuresFactors.factorLevelMap[rowSplitRM.columnsNames[0]]
+														 : rowSplitRM.levels)
+													  : [];
+										   addEmptyValue: groupValue.columnsNames.length === 0; placeholderText: qsTr("<No Value>");
+										   onEnabledChanged: { if (!enabled) currentIndex = -1 } }
 
-									/* facet selectors – RM */
-									DropDown { name: "RMColumnCompLine"; label: qsTr("Column"); visible: yesRM.checked; enabled: yesRM.checked;
-											   info: qsTr("Facet column (RM)"); values: colSplitRM.columnsNames.length > 0
-														  ? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(colSplitRM.columnsNames[0])
-															 ? repeatedMeasuresFactors.factorLevelMap[colSplitRM.columnsNames[0]]
-															 : colSplitRM.levels)
-														  : [];
-											   addEmptyValue: groupValue.columnsNames.length === 0; placeholderText: qsTr("<No Value>");
-											   onEnabledChanged: { if (!enabled) currentIndex = -1 } }
+								DropDown { name: "RMGridCompLine"; label: qsTr("Grid"); visible: yesRM.checked; enabled: yesRM.checked;
+										   info: qsTr("Facet grid cell (RM)"); values: gridVarRM.columnsNames.length > 0
+													  ? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(gridVarRM.columnsNames[0])
+														 ? repeatedMeasuresFactors.factorLevelMap[gridVarRM.columnsNames[0]]
+														 : gridVarRM.levels)
+													  : [];
+										   addEmptyValue: groupValue.columnsNames.length === 0; placeholderText: qsTr("<No Value>");
+										   onEnabledChanged: { if (!enabled) currentIndex = -1 } }}
+							/* facet selectors – noRM */
 
-									DropDown { name: "RMRowCompLine"; label: qsTr("Row"); visible: yesRM.checked; enabled: yesRM.checked;
-											   info: qsTr("Facet row (RM)"); values: rowSplitRM.columnsNames.length > 0
-														  ? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(rowSplitRM.columnsNames[0])
-															 ? repeatedMeasuresFactors.factorLevelMap[rowSplitRM.columnsNames[0]]
-															 : rowSplitRM.levels)
-														  : [];
-											   addEmptyValue: groupValue.columnsNames.length === 0; placeholderText: qsTr("<No Value>");
-											   onEnabledChanged: { if (!enabled) currentIndex = -1 } }
+						}
 
-									DropDown { name: "RMGridCompLine"; label: qsTr("Grid"); visible: yesRM.checked; enabled: yesRM.checked;
-											   info: qsTr("Facet grid cell (RM)"); values: gridVarRM.columnsNames.length > 0
-														  ? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(gridVarRM.columnsNames[0])
-															 ? repeatedMeasuresFactors.factorLevelMap[gridVarRM.columnsNames[0]]
-															 : gridVarRM.levels)
-														  : [];
-											   addEmptyValue: groupValue.columnsNames.length === 0; placeholderText: qsTr("<No Value>");
-											   onEnabledChanged: { if (!enabled) currentIndex = -1 } }}
-								/* facet selectors – noRM */
+						/* ── Appearance ── */
+						Group {
+							title: qsTr("Appearance")
+							info: qsTr("Line colour and label styling")
 
+							TextField {
+								name: "colorAnnotationLine"
+								label: qsTr("Line color")
+								info: qsTr("Named or hex colour for the line")
+								placeholderText: qsTr("e.g. black, #ff5733")
+								defaultValue: "black"
+								fieldWidth: 60
 							}
 
-							/* ── Appearance ── */
-							Group {
-								title: qsTr("Appearance")
-								info: qsTr("Line colour and label styling")
+							DoubleField {
+								name: "textSizeAnnotationLine"
+								label: qsTr("Label size")
+								info: qsTr("Font size of the label text")
+								defaultValue: 5.5
+								fieldWidth: 60
+							}
 
-								TextField {
-									name: "colorAnnotationLine"
-									label: qsTr("Line color")
-									info: qsTr("Named or hex colour for the line")
-									placeholderText: qsTr("e.g. black, #ff5733")
-									defaultValue: "black"
-									fieldWidth: 60
-								}
-
-								DoubleField {
-									name: "textSizeAnnotationLine"
-									label: qsTr("Label size")
-									info: qsTr("Font size of the label text")
-									defaultValue: 5.5
-									fieldWidth: 60
-								}
-
-								DoubleField {
-									name: "textDistanceAnnotationLine"
-									label: qsTr("Label distance")
-									info: qsTr("Vertical offset between the line and its label (data units)")
-									defaultValue: 0.5
-									fieldWidth: 60
-								}
+							DoubleField {
+								name: "textDistanceAnnotationLine"
+								label: qsTr("Label distance")
+								info: qsTr("Vertical offset between the line and its label (data units)")
+								defaultValue: 0.5
+								fieldWidth: 60
 							}
 						}
 					}
 				}
 			}
-
 		}
+
 	}
+}
 
-	Section {
-		title: qsTr("Plot layout")
-		columns: 1
+Section {
+	title: qsTr("Plot layout")
+	columns: 1
 
-		/* section-level help */
-		info: qsTr("Combine multiple plots in custom grids. "
-				 + "<b>Arrange plots by column</b> builds the top part of the layout, "
-				 + "<b>Arrange plots by row</b> builds the bottom. "
-				 + "Specify plot IDs, relative sizes and optional common legends")
+	/* section-level help */
+	info: qsTr("Combine multiple plots in custom grids. "
+			 + "<b>Arrange plots by column</b> builds the top part of the layout, "
+			 + "<b>Arrange plots by row</b> builds the bottom. "
+			 + "Specify plot IDs, relative sizes and optional common legends")
 
-		Group {
-			title: qsTr("Arrange plots by column")
+	Group {
+		title: qsTr("Arrange plots by column")
 
-			/* relative width string */
-			TextField {
-				name: "columnWidthInput"
-				label: qsTr("Relative column widths")
-				info: qsTr("Comma-separated numbers that set the width of each column")
-				placeholderText: qsTr("1,1")
-			}
+		/* relative width string */
+		TextField {
+			name: "columnWidthInput"
+			label: qsTr("Relative column widths")
+			info: qsTr("Comma-separated numbers that set the width of each column")
+			placeholderText: qsTr("1,1")
+		}
 
-			ComponentsList {
-				id: rowSpecifications
-				name: "rowSpecifications"
-				title: qsTr("Specify layout")
-				addItemManually: true
-				Layout.preferredWidth: form.width - 2 * jaspTheme.generalAnchorMargin
+		ComponentsList {
+			id: rowSpecifications
+			name: "rowSpecifications"
+			title: qsTr("Specify layout")
+			addItemManually: true
+			Layout.preferredWidth: form.width - 2 * jaspTheme.generalAnchorMargin
 
-				rowComponent: Row {
-					Group {
-						title: qsTr("Column ") + (rowIndex + 1)
+			rowComponent: Row {
+				Group {
+					title: qsTr("Column ") + (rowIndex + 1)
 
-						TextField {
-							name: "plotIDs"
-							label: qsTr("Plot IDs")
-							info: qsTr("Comma-separated IDs referencing earlier plots")
-							placeholderText: qsTr("Plot 1, Plot 2, ...")
-						}
-
-						TextField {
-							name: "rowHeightsColumn"
-							label: qsTr("Plot heights")
-							info: qsTr("Relative heights of plots within this column")
-							placeholderText: qsTr("1,1")
-						}
+					TextField {
+						name: "plotIDs"
+						label: qsTr("Plot IDs")
+						info: qsTr("Comma-separated IDs referencing earlier plots")
+						placeholderText: qsTr("Plot 1, Plot 2, ...")
 					}
 
-					Group {
-						title: " "
-
-						TextField {
-							name: "labelsColumn"
-							label: qsTr("Labels")
-							info: qsTr("Optional plot labels (A, B, …)")
-							placeholderText: qsTr("A, B, C, ...")
-							fieldWidth: 150
-						}
-
-						CheckBox {
-							name: "getCommonLegendColumn"
-							label: qsTr("Collect legend")
-							info: qsTr("Merge legends of all plots in this column")
-						}
+					TextField {
+						name: "rowHeightsColumn"
+						label: qsTr("Plot heights")
+						info: qsTr("Relative heights of plots within this column")
+						placeholderText: qsTr("1,1")
 					}
 				}
-			}
-		}
-
-		Group {
-			title: qsTr("Arrange plots by row")
-
-			TextField {
-				name: "relHeightWithinRowLayout"
-				label: qsTr("Relative row heights")
-				info: qsTr("Comma-separated numbers that set the height of each row")
-				placeholderText: "1,1"
-			}
-
-			ComponentsList {
-				id: fullRowSpecifications
-				name: "fullRowSpecifications"
-				title: qsTr("Specify layout")
-				addItemManually: true
-				Layout.preferredWidth: form.width - 2 * jaspTheme.generalAnchorMargin
-
-				rowComponent: Row {
-					Group {
-						title: qsTr("Row ") + (rowIndex + 1)
-
-						TextField {
-							name: "plotIDsFullRow"
-							label: qsTr("Plot IDs")
-							info: qsTr("Comma-separated IDs referencing earlier plots")
-							placeholderText: qsTr("Plot 1, Plot 2, ...")
-						}
-
-						TextField {
-							name: "relWidthsFullRow"
-							label: qsTr("Plot widths")
-							info: qsTr("Relative widths of plots within this row")
-							placeholderText: "1,1"
-						}
-					}
-
-					Group {
-						title: " "
-
-						TextField {
-							name: "labelsFullRow"
-							label: qsTr("Labels")
-							info: qsTr("Optional plot labels (A, B, …)")
-							placeholderText: qsTr("A, B, C, ...")
-							fieldWidth: 150
-						}
-
-						CheckBox {
-							name: "getCommonLegendRows"
-							label: qsTr("Collect legend")
-							info: qsTr("Merge legends of all plots in this row")
-						}
-					}
-				}
-			}
-		}
-
-		Label {
-			text: qsTr("Note: If you have column and row arrangement,\n"
-					   + "the column will be the top part of the layout\n"
-					   + "and the row will be the bottom part of the layout.")
-			wrapMode: Text.Wrap
-			color: "black"
-		}
-
-		/* label settings -------------------------------------------------- */
-		Group {
-			columns: 3
-			title: qsTr("Label settings")
-
-			DoubleField {
-				name: "labelSize"
-				label: qsTr("Label size")
-				info: qsTr("Font size of subplot labels")
-				value: 18
-			}
-
-			DoubleField {
-				name: "labelDistance1"
-				label: qsTr("Horizontal position")
-				info: qsTr("Horizontal offset of labels (0–1, relative to plot width)")
-				value: 0.05
-				min: 0
-				max: 1
-			}
-
-			DoubleField {
-				name: "labelDistance2"
-				label: qsTr("Vertical position")
-				info: qsTr("Vertical offset of labels (0–1, relative to plot height)")
-				value: 0.95
-				min: 0
-				max: 1
-			}
-		}
-
-		/* additional layout sizing --------------------------------------- */
-		Group {
-			title: qsTr("Additional settings")
-
-			Row {
-				spacing: 20
 
 				Group {
+					title: " "
+
 					TextField {
-						name: "relativeHeight"
-						label: qsTr("Column heights/row widths")
-						info: qsTr("Relative heights of columns or widths of rows when combining column and row layouts")
-						placeholderText: "1,1"
+						name: "labelsColumn"
+						label: qsTr("Labels")
+						info: qsTr("Optional plot labels (A, B, …)")
+						placeholderText: qsTr("A, B, C, ...")
 						fieldWidth: 150
 					}
 
-					DoubleField {
-						name: "layoutWidth"
-						label: qsTr("Width")
-						info: qsTr("Overall width of the assembled layout (pixels)")
-						value: 500
-					}
-
-					DoubleField {
-						name: "layoutHeight"
-						label: qsTr("Height")
-						info: qsTr("Overall height of the assembled layout (pixels)")
-						value: 500
-					}
-
-					DoubleField {
-						name: "plotSpacing"
-						label: qsTr("Spacing")
-						info: qsTr("Gap between plots inside the layout (pixels)")
-						value: 10
-					}
-
 					CheckBox {
-						name: "getCommonLegend"
-						label: qsTr("Collect legend across layout")
-						info: qsTr("Place a single shared legend for all plots in the layout")
+						name: "getCommonLegendColumn"
+						label: qsTr("Collect legend")
+						info: qsTr("Merge legends of all plots in this column")
 					}
 				}
 			}
 		}
 	}
+
+	Group {
+		title: qsTr("Arrange plots by row")
+
+		TextField {
+			name: "relHeightWithinRowLayout"
+			label: qsTr("Relative row heights")
+			info: qsTr("Comma-separated numbers that set the height of each row")
+			placeholderText: "1,1"
+		}
+
+		ComponentsList {
+			id: fullRowSpecifications
+			name: "fullRowSpecifications"
+			title: qsTr("Specify layout")
+			addItemManually: true
+			Layout.preferredWidth: form.width - 2 * jaspTheme.generalAnchorMargin
+
+			rowComponent: Row {
+				Group {
+					title: qsTr("Row ") + (rowIndex + 1)
+
+					TextField {
+						name: "plotIDsFullRow"
+						label: qsTr("Plot IDs")
+						info: qsTr("Comma-separated IDs referencing earlier plots")
+						placeholderText: qsTr("Plot 1, Plot 2, ...")
+					}
+
+					TextField {
+						name: "relWidthsFullRow"
+						label: qsTr("Plot widths")
+						info: qsTr("Relative widths of plots within this row")
+						placeholderText: "1,1"
+					}
+				}
+
+				Group {
+					title: " "
+
+					TextField {
+						name: "labelsFullRow"
+						label: qsTr("Labels")
+						info: qsTr("Optional plot labels (A, B, …)")
+						placeholderText: qsTr("A, B, C, ...")
+						fieldWidth: 150
+					}
+
+					CheckBox {
+						name: "getCommonLegendRows"
+						label: qsTr("Collect legend")
+						info: qsTr("Merge legends of all plots in this row")
+					}
+				}
+			}
+		}
+	}
+
+	Label {
+		text: qsTr("Note: If you have column and row arrangement,\n"
+				   + "the column will be the top part of the layout\n"
+				   + "and the row will be the bottom part of the layout.")
+		wrapMode: Text.Wrap
+		color: "black"
+	}
+
+	/* label settings -------------------------------------------------- */
+	Group {
+		columns: 3
+		title: qsTr("Label settings")
+
+		DoubleField {
+			name: "labelSize"
+			label: qsTr("Label size")
+			info: qsTr("Font size of subplot labels")
+			value: 18
+		}
+
+		DoubleField {
+			name: "labelDistance1"
+			label: qsTr("Horizontal position")
+			info: qsTr("Horizontal offset of labels (0–1, relative to plot width)")
+			value: 0.05
+			min: 0
+			max: 1
+		}
+
+		DoubleField {
+			name: "labelDistance2"
+			label: qsTr("Vertical position")
+			info: qsTr("Vertical offset of labels (0–1, relative to plot height)")
+			value: 0.95
+			min: 0
+			max: 1
+		}
+	}
+
+	/* additional layout sizing --------------------------------------- */
+	Group {
+		title: qsTr("Additional settings")
+
+		Row {
+			spacing: 20
+
+			Group {
+				TextField {
+					name: "relativeHeight"
+					label: qsTr("Column heights/row widths")
+					info: qsTr("Relative heights of columns or widths of rows when combining column and row layouts")
+					placeholderText: "1,1"
+					fieldWidth: 150
+				}
+
+				DoubleField {
+					name: "layoutWidth"
+					label: qsTr("Width")
+					info: qsTr("Overall width of the assembled layout (pixels)")
+					value: 500
+				}
+
+				DoubleField {
+					name: "layoutHeight"
+					label: qsTr("Height")
+					info: qsTr("Overall height of the assembled layout (pixels)")
+					value: 500
+				}
+
+				DoubleField {
+					name: "plotSpacing"
+					label: qsTr("Spacing")
+					info: qsTr("Gap between plots inside the layout (pixels)")
+					value: 10
+				}
+
+				CheckBox {
+					name: "getCommonLegend"
+					label: qsTr("Collect legend across layout")
+					info: qsTr("Place a single shared legend for all plots in the layout")
+				}
+			}
+		}
+	}
+}
 
 }
 

--- a/inst/qml/jaspPlotBuilder.qml
+++ b/inst/qml/jaspPlotBuilder.qml
@@ -1,4 +1,4 @@
-//
+	//
 // Copyright (C) 2013-2024 University of Amsterdam
 //
 // This program is free software: you can redistribute it and/or modify
@@ -26,6 +26,16 @@ import JASP.Controls
 Form {
 	columns: 1
 
+	info: qsTr("The <b>Plot Builder (beta)</b> lets you assemble a complete figure in just a few clicks.<br/><br/>"
+			+ "1. <b>Decide on design:</b> At the very top choose <i>Repeated measurements → Yes</i> if the same subjects are measured more than once "
+			+ "(e.g., across time-points or conditions); otherwise leave <i>No</i> selected. "
+			+ "2. <b>Map your variables:</b> Drag variables from the list on the left into the fields on the right (X-Axis, Y-Axis, etc). "
+			+ "3. <b>Choose what to display:</b> Expand the <i>Data and geometries</i> accordion to add layers such as raw points, histograms/box-/violin plots, "
+			+ "counts, proportions, Mean or Median summaries, etc. "
+			+ "4. <b>Polish the figure:</b> Use the remaining accordions to fine-tune axes, titles, annotations, themes, colors, sizing, and legend placement.")
+
+
+
 	infoBottom:
 		"## " + qsTr("References") + "\n" +
 		"- Engler, J. B. (2025). “Tidyplots Empowers Life Scientists With Easy Code-Based Data Visualization.” _iMeta_, 4, e70018. https://doi.org/10.1002/imt2.70018\n" +
@@ -41,18 +51,16 @@ Form {
 		"- Dunnington, D. (2023). _ggeasy: Easy Access to 'ggplot2' Commands_. R package version 0.1.4. Available at: <https://CRAN.R-project.org/package=ggeasy>.\n" +
 		"- Wickham, H., & Henry, L. (2023). _forcats: Tools for Working with Categorical Variables (Factors)_. R package version 1.0.0. Available at: <https://CRAN.R-project.org/package=forcats>.\n"
 
-
 	TabView {
-
+		infoLabel: qsTr("The basic setup: decide on the design (repeated-measures or non-repeated-measures) and select the variables")
 		name: "PlotBuilderTab"
 		newItemName: qsTr("Plot 1")
-
 		rowComponent: Group {
 
 			childControlsArea.anchors.leftMargin: jaspTheme.contentMargin
 
 			Group{
-				columns:2
+				columns:3
 				RadioButtonGroup {
 					id:						isRM
 					Layout.columnSpan:		1
@@ -60,10 +68,11 @@ Form {
 					title:					qsTr("Repeated measurements")
 					radioButtonsOnSameRow:	true
 					columns:				2
-					info: qsTr("Choose whether you want to make plots of repeated measurements from repeated measurements.")
+					info: qsTr("Select whether you want to create a repeated-measures plot or a non-repeated-measures plot")
 
 					RadioButton {
 						label:		qsTr("No")
+						info: qsTr("Select this to create a non-repeated-measures plot")
 						value:		"noRM"
 						id:			noRM
 						checked:	true
@@ -71,22 +80,33 @@ Form {
 
 					RadioButton {
 						label:		qsTr("Yes")
+						info: qsTr("Select this to create a repeated-measures plot")
 						value:		"RM"
 						id:          yesRM
 					}
+				}
+
+				CheckBox{
+				name: "deleteNAListwise"
+				id: deleteNAlistwise
+				checked: true
+				visible: yesRM.checked
+				enabled: yesRM.checked
+				info: qsTr("ON (listwise deletion): if a case is missing even one of the selected variables, the whole case is excluded."
+						   + "OFF: keep every case and ignore only the specific values that are missing")
+				label: qsTr("Delete missing values listwise")
 				}
 			}
 
 			Group {
 				VariablesForm {
 
-					removeInvisibles:	true
+					removeInvisibles:true
 					preferredWidth: jaspForm.width - 2 * jaspTheme.contentMargin
 					preferredHeight: 300 * jaspTheme.uiScale
 					visible: noRM.checked
 
-
-					infoLabel: qsTr("Input")
+					infoLabel: qsTr("Input for non-repeated measures plot")
 
 					// NO RM DATASET -------------------------------------------------------------------------------------------------------------------------
 
@@ -101,7 +121,7 @@ Form {
 						allowedColumns: ["scale", "ordinal", "nominal"]
 						minLevels: 2
 						singleVariable: true
-						info: qsTr("Select the variable for the X-axis.")
+						info: qsTr("Select the variable for the X-Axis")
 					}
 
 					AssignedVariablesList {
@@ -110,7 +130,7 @@ Form {
 						allowedColumns: ["scale", "ordinal", "nominal"]
 						id: variableYPlotBuilder
 						singleVariable: true
-						info: qsTr("Select the variable for the Y-axis.")
+						info: qsTr("Select the variable for the Y-Axis")
 					}
 
 					AssignedVariablesList {
@@ -121,7 +141,7 @@ Form {
 						minLevels: 2
 						visible: !yesRM.checked
 						singleVariable: true
-						info: qsTr("Select the variable for data grouping, which will also determine the coloring..")
+						info: qsTr("Select the variable for data grouping, which will also determine the coloring.")
 						onCountChanged: {
 							if (count > 0) {
 								colorByVariableX.checked = false;
@@ -136,7 +156,7 @@ Form {
 						id: columnsvariableSplitPlotBuilder
 						allowedColumns: ["ordinal", "nominal"]
 						singleVariable: true
-						info: qsTr("You can choose a variable to split the plots into columns.")
+						info: qsTr("You can choose a variable to split the plots into columns")
 					}
 
 					AssignedVariablesList {
@@ -145,7 +165,7 @@ Form {
 						id: rowsvariableSplitPlotBuilder
 						allowedColumns: ["ordinal", "nominal"]
 						singleVariable: true
-						info: qsTr("You can choose a variable to split the plots into rows.")
+						info: qsTr("You can choose a variable to split the plots into rows")
 
 					}
 
@@ -155,11 +175,11 @@ Form {
 						id: gridVariablePlotBuilder
 						allowedColumns: ["ordinal", "nominal"]
 						singleVariable: true
-						info: qsTr("You can choose a variable to make a grid.")
+						info: qsTr("You can choose a variable to make a grid")
 					}
 				}
 
-					//  RM DATASET ---------------------------------------------------------------------------------------------------------------------------
+				//  RM DATASET ---------------------------------------------------------------------------------------------------------------------------
 
 				VariablesForm {
 
@@ -168,7 +188,7 @@ Form {
 					preferredHeight: 600  * jaspTheme.uiScale
 					visible: yesRM.checked
 
-					infoLabel: qsTr("Input")
+					infoLabel: qsTr("Input for repeated measures plot")
 
 					AvailableVariablesList {
 						name: "allVariablesListRM"
@@ -179,6 +199,7 @@ Form {
 						name: "repeatedMeasuresFactors";
 						id: repeatedMeasuresFactors
 						title: qsTr("Repeated Measures Factors")
+						info:qsTr("Here you can specify the factor for the repeated measures. For example, it could be time (e.g., 24 h, 48 h, 72 h) or conditions like before and after")
 						height: 180 * preferencesModel.uiScale;	factorName: qsTr("RM Factor")
 
 					}
@@ -186,21 +207,23 @@ Form {
 					AssignedRepeatedMeasuresCells {
 						id: rmCells
 						name: "repeatedMeasuresCells"
+						info: qsTr("Assign the variables that correspond to each level of the repeated measures factor. For example, if the factor is time, assign variables like '24h', '48h', and '72h'")
 						title: qsTr("Repeated Measures Cells")
 						source: "repeatedMeasuresFactors"
 					}
 
-
 					AssignedVariablesList {
 						name: "betweenSubjectFactors"
 						title: qsTr("Between Subject Factors")
+						info: qsTr("Select the between-subject factors that distinguish different groups of subjects, such as treatment group, gender, or genotype. These variables must be categorical (nominal) with at least two levels")
 						allowedColumns: ["nominal"]
 						minLevels: 2
-
 					}
+
 					AssignedVariablesList {
 						name: "covariates"
 						title: qsTr("Covariates")
+						info: qsTr("Select continuous variables that may influence the outcome and should be included as covariates in the analysis")
 						allowedColumns: ["scale"]
 						minNumericLevels: 2
 					}
@@ -208,10 +231,15 @@ Form {
 
 				}
 
-			} // End variables
+			} //
+
+			/* -------------------------------------------------------------------
+			   Point annotations – repelled data-labels
+			   ------------------------------------------------------------------- */
 
 
 			Section{
+				// infoLabel: qsTr("Here you can define the role of the repeated measures variables in the plot.")
 				visible: yesRM.checked
 				title: qsTr("Assign repeated measures components")
 				VariablesForm {
@@ -224,22 +252,31 @@ Form {
 						name: "withinComponents"
 						title: qsTr("Repeated Measures Components")
 						source: ["repeatedMeasuresFactors", "betweenSubjectFactors", "covariates"]
+						enabled: yesRM.checked
+						onEnabledChanged: {
+							if (enabled) {
+								while (count > 0) {
+									itemDoubleClicked(0)
+								}
+							}
+						}
 					}
 
 					AssignedVariablesList {
 						id: xVarRM
 						allowedColumns: ["scale", "ordinal", "nominal"]
 						name: "xVarRM"
+						info: qsTr("Select the variable for the X-Axis")
 						title: qsTr("X-Axis Variable")
 						singleVariable: true
 					}
-
 
 					AssignedVariablesList {
 						id: groupVarRM
 						name: "groupVarRM"
 						title: qsTr("Group Variable")
 						singleVariable: true
+						info: qsTr("Select the variable for data grouping, which will also determine the coloring")
 						allowedColumns: ["scale", "ordinal", "nominal"]
 					}
 
@@ -248,8 +285,8 @@ Form {
 						title: qsTr("Split (Columns)")
 						id: colSplitRM
 						allowedColumns: ["ordinal", "nominal"]
+						info: qsTr("You can choose a variable to split the plots into columns")
 						singleVariable: true
-						info: qsTr("You can choose a variable to split the plots into columns.")
 					}
 
 					AssignedVariablesList {
@@ -258,7 +295,7 @@ Form {
 						id: rowSplitRM
 						allowedColumns: ["ordinal", "nominal"]
 						singleVariable: true
-						info: qsTr("You can choose a variable to split the plots into rows.")
+						info: qsTr("You can choose a variable to split the plots into rows")
 					}
 
 					AssignedVariablesList {
@@ -267,10 +304,9 @@ Form {
 						id: gridVarRM
 						allowedColumns: ["ordinal", "nominal"]
 						singleVariable: true
-						info: qsTr("You can choose a variable to make a grid.")
+						info: qsTr("You can choose a variable to make a grid")
 					}
 				}
-
 			}
 
 			Label {
@@ -285,7 +321,7 @@ Form {
 			// -------------------------------------------------------------------
 
 
-			Section {
+		Section {
 				title: qsTr("Individual data points")
 
 				Label {
@@ -298,7 +334,7 @@ Form {
 					name: "addDataPoint"
 					label: qsTr("Individual data points")
 					id: addDataPoint
-					info: qsTr("Check this option to show individual data points on the plot.")
+					info: qsTr("Check this option to show individual data points on the plot")
 					columns: 4
 					enabled: (
 								 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
@@ -322,17 +358,34 @@ Form {
 
 					Group {
 						DoubleField {
+							info: qsTr("Set the point size")
 							name: "pointsizePlotBuilder"
 							id: pointsizePlotBuilder
 							label: qsTr("Point size")
+							enabled: !sizeByVariable.checked
 							value: 3
 							min: 0
 							max: 10
+						}
+
+						CheckBox{
+						name:"sizeByVariable"
+						id: sizeByVariable
+						label: qsTr("Size by variable")
+						info: qsTr("Choose this if you want the point size to be determined by a variable rather than a fixed constant")
+						}
+
+						CheckBox{
+						name:"shapebyVariable"
+						id: shapebyVariable
+						label: qsTr("Shape by variable")
+						info: qsTr("Choose this if you want the point shape to be determined by a variable")
 						}
 					}
 
 					Group {
 						DoubleField {
+							info: "A small “jitter” is added to the individual data points displayed to prevent overlaps. Here you can adjust the height of the jitter."
 							name: "jitterhPlotBuilder"
 							id: jitterhPlotBuilder
 							label: qsTr("Jitter height")
@@ -340,7 +393,9 @@ Form {
 							min: 0
 							max: 10
 						}
+
 						DoubleField {
+							info: "A small “jitter” is added to the individual data points displayed to prevent overlaps. Here you can adjust the width of the jitter."
 							name: "jitterwPlotBuilder"
 							id: jitterwPlotBuilder
 							label: qsTr("Jitter width")
@@ -355,13 +410,18 @@ Form {
 							name: "alphaPlotBuilder"
 							id: alphaPlotBuilder
 							label: qsTr("Transparency")
+							info: qsTr("Set the transparency")
 							value: 0.5
 							min: 0
 							max: 1
 						}
+
 						DoubleField {
 							name: "pointDodgePlotBuilder"
 							label: qsTr("Dodge")
+							info: qsTr("Adjusts the horizontal “dodge” spacing between subgroup geometric elements. "
+									  + "Only takes effect when a grouping variable is mapped (e.g., male vs. female within each species). "
+									  + "A value of 0 overlays the elements; higher values push the subgroups farther apart")
 							id: pointDodgePlotBuilder
 							defaultValue: 0.8
 						}
@@ -372,16 +432,173 @@ Form {
 							name: "blackOutlineDataPoint"
 							label: qsTr("Black outline")
 							checked: false
+							enabled: !shapebyVariable.checked
+							info: qsTr("Add a black outline/border to the elements")
+							onEnabledChanged: {
+								if (!enabled) {
+									checked = false;
+								}
+							}
+						}
+
+						CheckBox {
+							name: "whiteBorder"
+							label: qsTr("White outline")
+							checked: false
+							enabled: !shapebyVariable.checked
+							info: qsTr("Add a white outline/border to the elements")
+							onEnabledChanged: {
+								if (!enabled) {
+									checked = false;
+								}
+							}
 						}
 
 						CheckBox {
 							name: "emptyCircles"
 							label: qsTr("Empty circles")
 							checked: false
+							enabled: !shapebyVariable.checked
+							info: qsTr("Remove the fill")
+							onEnabledChanged: {
+								if (!enabled) {
+									checked = false;
+								}
+							}
 						}
 					}
 
 				}
+
+				VariablesForm{
+					visible: sizeByVariable.checked
+					enabled: sizeByVariable.checked
+					preferredWidth: jaspForm.width - 2 * jaspTheme.contentMargin
+					preferredHeight: 100 * preferencesModel.uiScale
+
+					AvailableVariablesList {
+						name: "sizeVars"
+						source: [
+							{ name: "allVariablesList", use: "type=scale|ordinal" },
+							{ name: "allVariablesListRM", use: "type=scale|ordinal" }
+						]
+					}
+
+					AssignedVariablesList {
+						id: sizeVariablePlotBuilder
+						allowedColumns: ["scale", "ordinal"]
+						enabled: sizeByVariable.checked
+						name: "sizeVariablePlotBuilder"
+						title: qsTr("Point Size Variable")
+						singleVariable: true
+						onEnabledChanged: {
+							if (!enabled) {
+								while (count > 0) {
+									itemDoubleClicked(0)
+								}
+							}
+						}
+					}
+
+					Group{
+					columns:2
+					DoubleField {
+						name: "pointSizeMin"
+						label: qsTr("Min point size")
+						value: 1
+
+					}
+					DoubleField {
+						name: "pointSizeMax"
+						label: qsTr("Max point size")
+						value: 4
+
+					}
+					}
+				}
+
+				VariablesForm{
+					preferredWidth: jaspForm.width - 2 * jaspTheme.contentMargin
+					preferredHeight: 100 * preferencesModel.uiScale
+					visible: shapebyVariable.checked
+					enabled: shapebyVariable.checke
+
+					AvailableVariablesList {
+						name: "shapeVars"
+						source: [
+							{ name: "allVariablesList",   use: "type=nominal|ordinal" },
+							{ name: "allVariablesListRM", use: "type=nominal|ordinal" }
+						]
+					}
+
+
+
+					AssignedVariablesList {
+						id: pointShapeVariable
+						allowedColumns: ["nominal", "ordinal"]
+						name: "pointShapeVariable"
+						title: qsTr("Point Shape Variable")
+						singleVariable: true
+						enabled: shapebyVariable.checked
+						onEnabledChanged: {
+							if (!enabled) {
+								while (count > 0) {
+									itemDoubleClicked(0)
+								}
+							}
+						}
+					}
+
+				}
+
+
+				CheckBox { ///////////////////////
+					name: "addStatEllipse"
+					label: qsTr("Add ellipse")
+					checked: false
+					enabled: addDataPoint.checked
+					columns: 3
+					info: qsTr("Add a statistical ellipse around the points."
+					+ "'Ellipse type' controls the method:"
+					+ "\"t\" assumes a multivariate t-distribution,"
+					+ "\"Normal\" assumes a multivariate normal distribution,"
+					+ "and \"Euclidean\" draws a circle whose radius equals the value of 'Level'")
+					onEnabledChanged: {
+						if (!enabled) {
+							checked = false;
+						}
+					}
+
+					DropDown {
+						name: "ellipseType"
+						label: qsTr("Ellipse type")
+						values: [
+							{ label: qsTr("t"), value: "t" },
+							{ label: qsTr("Normal"), value: "norm" },
+							{ label: qsTr("Euclidean"), value: "euclid"}
+						]
+						indexDefaultValue: 0
+					}
+
+					DoubleField {
+						name: "fillEllipse"
+						label: qsTr("Transparency")
+						value: 0.20
+						min: 0
+						max: 1
+					}
+
+					DoubleField {
+						name: "levelEllipse"
+						label: qsTr("Level")
+						value: 0.95
+						min: 0
+						max: 1
+						info: qsTr("Confidence level (for t and normal ellipse type) or radius (euclidean ellipse type)")
+					}
+
+				} /////////////////////////////////////////
+
 
 				CheckBox {
 					name: "connectRMPlotBuilder"
@@ -389,6 +606,7 @@ Form {
 					id: connectRMPlotBuilder
 					checked: false
 					enabled: isRM.value === "RM" & addDataPoint.checked
+					columns: 2
 					onEnabledChanged: {
 						if (!enabled) {
 							checked = false;
@@ -409,6 +627,7 @@ Form {
 
 
 				}
+
 			}
 
 			// -------------------------------------------------------------------
@@ -429,37 +648,112 @@ Form {
 					rowSpacing: 40
 					columnSpacing: 40
 
-					// Histogram
-					CheckBox {
-						name: "addHistogram"
-						id: addHistogram
-						label: qsTr("Histogram")
-						info: qsTr("Check this option to create histogram for x or y variables. Histogram requires either X-Axis or X-Axis variable, but not both.")
-						enabled: (variableXPlotBuilder.count > 0 || variableYPlotBuilder.count > 0)
-								 && !(variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
 
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
+					Group{
+
+						// Histogram
+						CheckBox {
+							name: "addHistogram"
+							id: addHistogram
+							label: qsTr("Histogram")
+							info: qsTr("Check this option to create histogram for x or y variables. Histogram requires either X-Axis or X-Axis variable, but not both.")
+							enabled: (variableXPlotBuilder.count > 0 || variableYPlotBuilder.count > 0)
+									 && !(variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+
+							onEnabledChanged: {
+								if (!enabled) {
+									checked = false;
+								}
+							}
+
+							DoubleField {
+								name: "binsPlotBuilder"
+								label: qsTr("Number of bins")
+								info: qsTr("Sets the number of bins used to divide the data range in histograms."
+										 + "More bins give finer detail, fewer bins give a more general overview")
+								id: binsPlotBuilder
+								defaultValue: 30
+							}
+
+							DoubleField {
+								name: "alphaHistogramPlotBuilder"
+								label: qsTr("Transparency")
+								id: alphaHistogramPlotBuilder
+								defaultValue: 0.8
+								info: qsTr("Set the transparency")
+								min: 0
+								max: 1
+							}
+
+							CheckBox{
+							name: "blackHistogramOutline"
+							label: qsTr("Black outline")
 							}
 						}
 
-						DoubleField {
-							name: "binsPlotBuilder"
-							label: qsTr("Number of bins")
-							id: binsPlotBuilder
-							defaultValue: 30
+						// Density
+
+						CheckBox {
+							name: "addDensity"
+							id: addDensity
+							label: qsTr("Density")
+							info: qsTr("Check this option to overlay a density estimate on the histogram. Density can be shown as scaled (0–1) or on the histogram count scale.")
+							enabled: (variableXPlotBuilder.count > 0 || variableYPlotBuilder.count > 0)
+									 && !(variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+
+							// Density overlay mode radiobutton
+							RadioButtonGroup {
+								id: densityOverlayMode
+								name: "densityOverlayMode"
+								title: qsTr("Density overlay mode")
+								radioButtonsOnSameRow: false
+								columns: 1
+								info: qsTr("Choose whether the density curve is scaled to the histogram count ('Count'), or normalized to a maximum of 1 ('Scaled')")
+
+								RadioButton {
+									label: qsTr("Count")
+									info: qsTr("Show density on the histogram count scale (area under the curve equals total count)")
+									value: "count"
+									id: densityCount
+									checked: true
+								}
+
+								RadioButton {
+									label: qsTr("Scaled (0–1)")
+									info: qsTr("Show density scaled so that the maximum of the curve is 1")
+									value: "scaled"
+									id: densityScaled
+								}
+							}
+
+							DoubleField {
+								name: "alphaDensityPlotBuilder"
+								label: qsTr("Transparency")
+								id: alphaDensityPlotBuilder
+								defaultValue: 0.8
+								info: qsTr("Set the transparency for the density overlay")
+								min: 0
+								max: 1
+							}
+
+							DoubleField {
+								name: "lineWidthDensity"
+								label: qsTr("Line width")
+								id: lineWidthDensity
+								defaultValue: 0.8
+								info: qsTr("Set the line width for the density overlay")
+
+							}
+
+							CheckBox{
+							name: "blackDensityOutline"
+							label: qsTr("Black outline")
+							}
 						}
 
-						DoubleField {
-							name: "alphaHistogramPlotBuilder"
-							label: qsTr("Transparency")
-							id: alphaHistogramPlotBuilder
-							defaultValue: 1
-							min: 0
-							max: 1
-						}
 					}
+
+
 
 					// Boxplot
 
@@ -468,7 +762,7 @@ Form {
 						name: "addBoxplot"
 						id: addBoxplot
 						label: qsTr("Boxplot")
-						info: qsTr("Check this option to create boxplot. Boxplot and violin plot require both x-axis and y-axis variables.")
+						info: qsTr("Check this option to create boxplot. Boxplot and violin plot require both X-Axis and Y-Axis variables.")
 						enabled: (
 									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
 									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
@@ -493,6 +787,9 @@ Form {
 							name: "dodgeBoxplotPlotBuilder"
 							label: qsTr("Dodge")
 							id: dodgeBoxplotPlotBuilder
+							info: qsTr("Adjusts the horizontal “dodge” spacing between subgroup geometric elements. "
+									  + "Only takes effect when a grouping variable is mapped (e.g., male vs. female within each species). "
+									  + "A value of 0 overlays the elements; higher values push the subgroups farther apart")
 							defaultValue: 0.8}
 
 
@@ -500,6 +797,7 @@ Form {
 							name: "alphaBoxplotPlotBuilder"
 							label: qsTr("Transparency")
 							id: alphaBoxplotPlotBuilder
+							info: qsTr("Set the transparency")
 							defaultValue: 0.8
 							min: 0
 							max: 1
@@ -509,12 +807,15 @@ Form {
 							name: "widthLineBoxplotPlotBuilder"
 							label: qsTr("Line width")
 							id: widthLineBoxplotPlotBuilder
+							info: qsTr("Sets the line width of the geometric element (e.g., boxplot, violin, error bar). "
+									 + "Increase for thicker outlines, decrease for thinner ones")
 							defaultValue: 0.8
 						}
 
 						DoubleField {
 							name: "widthBoxplotPlotBuilder"
 							label: qsTr("Boxplot width")
+							info: qsTr("Set the width of the boxplots")
 							id: widthBoxplotPlotBuilder
 							defaultValue: 0.6
 						}
@@ -522,6 +823,7 @@ Form {
 						DoubleField {
 							name: "widthWhiskersPlotBuilder"
 							label: qsTr("Whiskers width")
+							info: qsTr("Sets the horizontal width of the whiskers in a boxplot")
 							id: widthWhiskersPlotBuilder
 							defaultValue: 0.3
 						}
@@ -530,12 +832,16 @@ Form {
 							name: "outlierBoxplotPlotBuilder"
 							label: qsTr("Show outliers")
 							id: outlierBoxplotPlotBuilder
+							info: qsTr("Displays individual outlier points beyond the whiskers in a boxplot. "
+										 + "Outliers are defined as values that fall outside the range of Q1 − coef × IQR and Q3 + coef × IQR")
 							checked: false
 						}
 
 						DoubleField {
 							name: "outlierCoefBoxplotPlotBuilder"
 							label: qsTr("Outlier coef")
+							info: qsTr("Sets the multiplier (coef) used to define outliers in a boxplot. "
+										+ "Outliers are values beyond Q1 − coef × IQR or Q3 + coef × IQR")
 							id: outlierCoefoxplotPlotBuilder
 							defaultValue: 1.5
 						}
@@ -543,6 +849,7 @@ Form {
 						DoubleField {
 							name: "outlierSizeBoxplotPlotBuilder"
 							label: qsTr("Outlier size")
+							info: qsTr("Set the size of the outliers")
 							id: outlierSizeBoxplotPlotBuilder
 							defaultValue: 1
 						}
@@ -551,7 +858,13 @@ Form {
 							name: "blackOutlineBoxplot"
 							label: qsTr("Black outline")
 							checked: true
-							info: qsTr("Enable black outline/fill for the boxplot geom.")
+							info: qsTr("Add a black outline/border to the elements")
+						}
+
+						CheckBox {
+							name: "whiteOutlineBoxplot"
+							info: qsTr("Add a white outline/border to the elements")
+							label: qsTr("White outline")
 						}
 
 
@@ -586,6 +899,9 @@ Form {
 						DoubleField {
 							name: "dodgeViolinPlotBuilder"
 							label: qsTr("Dodge")
+							info: qsTr("Adjusts the horizontal “dodge” spacing between subgroup geometric elements. "
+									  + "Only takes effect when a grouping variable is mapped (e.g., male vs. female within each species). "
+									  + "A value of 0 overlays the elements; higher values push the subgroups farther apart")
 							defaultValue: 0.8
 						}
 
@@ -594,6 +910,7 @@ Form {
 							label: qsTr("Transparency")
 							id: alphaViolinPlotBuilder
 							defaultValue: 0.8
+							info: qsTr("Set the transparency")
 							min: 0
 							max: 1
 						}
@@ -601,6 +918,8 @@ Form {
 						DoubleField {
 							name: "linewidthViolinPlotBuilder"
 							label: qsTr("Line width")
+							info: qsTr("Sets the line width of the geometric element (e.g., boxplot, violin, error bar). "
+									 + "Increase for thicker outlines, decrease for thinner ones")
 							id: linewidthViolinPlotBuilder
 							defaultValue: 0.8
 						}
@@ -608,6 +927,10 @@ Form {
 						DropDown {
 							name: "scaleViolinPlotBuilder"
 							label: qsTr("Scale method")
+							info: qsTr("Controls how the width of each violin is scaled:"
+									 + "<b>Area</b>: all violins have the same area (default in ggplot2)."
+									 + "<b>Count</b>: violins are scaled by the number of observations in each group."
+									 + "<b>Width</b>: all violins have the same maximum width, regardless of group size.")
 							id: scaleViolinPlotBuilder
 							values: [
 								{ label: qsTr("Area"), value: "area" },
@@ -620,6 +943,8 @@ Form {
 						FormulaField {
 							name: "drawQuantilesViolinPlotBuilder"
 							label: qsTr("Draw quantiles")
+							info: qsTr("Draws horizontal lines at the specified quantiles inside each violin. "
+									 + "Use comma-separated values between 0 and 1 (e.g., 0.25, 0.5, 0.75) to show quartiles or other custom quantiles.")
 							defaultValue: "0.25, 0.5, 0.75"
 						}
 
@@ -627,12 +952,23 @@ Form {
 							name: "trimViolinPlotBuilder"
 							label: qsTr("Trim violins")
 							id: trimViolinPlotBuilder
+							info: qsTr("If checked, the violins are trimmed to the range of the data. "
+									 + "If unchecked, the density tails may extend beyond the observed values.")
 							checked: false
 						}
 
 						CheckBox {
 							name: "blackOutlineViolin"
 							label: qsTr("Black outline")
+							info: qsTr("Add a black outline/border to the elements")
+
+						}
+
+						CheckBox {
+							name: "whiteOutlineViolin"
+							label: qsTr("White outline")
+							info: qsTr("Add a white outline/border to the elements")
+
 						}
 
 
@@ -649,14 +985,19 @@ Form {
 
 			Section {
 				title: qsTr("Amounts (count and sum)")
+				info: qsTr("This section adds layers that visualise amounts. "
+						 + "<b>Dodge</b> shifts subgroup geoms sideways so they don’t overlap. "
+						 + "<b>Size / Width</b> sets the thickness of bars and lines or the radius of dots. "
+						 + "<b>Transparency (alpha)</b> controls opacity: 0 = invisible, 1 = solid. "
+						 + "<b>Outline (black / white)</b> toggles a border around the shape. ")
+
+
 
 				Label {
 					text: qsTr("Required: X OR Y-Axis Variable")
 					wrapMode: Text.Wrap
 					color: "black"
 				}
-
-
 
 				GridLayout {
 					columns: 3
@@ -703,7 +1044,7 @@ Form {
 					CheckBox {
 						name: "addCountDash"
 						label: qsTr("Count dash")
-						info: qsTr("Enable to add dashed lines to the plot.")
+						info: qsTr("Enable to add dashed lines to the plot")
 						enabled: isRM.value === "noRM" && // can't use if RM
 								 ((variableXPlotBuilder.count > 0 && variableYPlotBuilder.count === 0) ||
 								  (variableXPlotBuilder.count === 0 && variableYPlotBuilder.count > 0))
@@ -747,7 +1088,7 @@ Form {
 					CheckBox {
 						name: "addCountDot"
 						label: qsTr("Count dot")
-						info: qsTr("Enable to add count dots to the plot.")
+						info: qsTr("Enable to add count dots to the plot")
 						enabled: isRM.value === "noRM" && // can't use if RM
 								 ((variableXPlotBuilder.count > 0 && variableYPlotBuilder.count === 0) ||
 								  (variableXPlotBuilder.count === 0 && variableYPlotBuilder.count > 0))
@@ -782,6 +1123,11 @@ Form {
 								name: "blackOutlineCountDot"
 								label: qsTr("Black outline")
 							}
+
+							CheckBox {
+								name: "whiteOutlineCountDot"
+								label: qsTr("White outline")
+							}
 						}
 					}
 
@@ -789,7 +1135,7 @@ Form {
 					CheckBox {
 						name: "addCountLine"
 						label: qsTr("Count line")
-						info: qsTr("Enable to add count lines to the plot.")
+						info: qsTr("Enable to add count lines to the plot")
 						enabled: isRM.value === "noRM" && // can't use if RM
 								 ((variableXPlotBuilder.count > 0 && variableYPlotBuilder.count === 0) ||
 								  (variableXPlotBuilder.count === 0 && variableYPlotBuilder.count > 0))
@@ -829,7 +1175,7 @@ Form {
 					CheckBox {
 						name: "addCountArea"
 						label: qsTr("Count area")
-						info: qsTr("Enable to add a count area to the plot.")
+						info: qsTr("Enable to add a count area to the plot")
 						enabled: isRM.value === "noRM" && // can't use if RM
 								 ((variableXPlotBuilder.count > 0 && variableYPlotBuilder.count === 0) ||
 								  (variableXPlotBuilder.count === 0 && variableYPlotBuilder.count > 0))
@@ -857,7 +1203,7 @@ Form {
 					CheckBox {
 						name: "addCountValue"
 						label: qsTr("Count value")
-						info: qsTr("Enable to add count values to the plot.")
+						info: qsTr("Enable to add count values to the plot")
 						enabled: isRM.value === "noRM" &&
 								 (
 									 (variableXPlotBuilder.count > 0 && variableYPlotBuilder.count === 0) ||
@@ -1063,6 +1409,10 @@ Form {
 							name: "blackOutlineSumDot"
 							label: qsTr("Black outline")
 						}
+						CheckBox {
+							name: "whiteOutlineSumDot"
+							label: qsTr("White outline")
+						}
 					}
 
 					// Sum Line
@@ -1223,36 +1573,43 @@ Form {
 
 			Section {
 				title: qsTr("Proportions")
-				columns:2
+
+				info: qsTr("Visualise how each subgroup contributes to the whole "
+						 + "Requires one Group variable plus either an X- or Y-axis variable "
+						 + "Absolute mode stacks raw counts; Relative mode rescales each stack to 0-1 or 0-100 % "
+						 + "Common controls: Transparency sets opacity, Reverse order flips the stack sequence, "
+						 + "Line width outlines area stacks, Replace N/A turns missing groups into a separate slice")
+				columns: 2
 
 				Label {
-					text: qsTr("Required: Group Variable AND X OR Y-Axis Variable")
+					text: qsTr("Required: Group Variable AND X- or Y-Axis Variable")
 					wrapMode: Text.Wrap
 					color: "black"
 					Layout.columnSpan: 2
 				}
 
-
 				RadioButtonGroup {
-					Layout.columnSpan: 2
 					id: propModeGroup
 					name: "propMode"
 					title: qsTr("Proportion mode")
 					radioButtonsOnSameRow: true
 					columns: 2
+					Layout.columnSpan: 2
+
 					RadioButton {
 						value: "absolute"
 						label: qsTr("Absolute")
 						checked: true
+						info: qsTr("Stack heights show raw counts")
 					}
 					RadioButton {
+						id: relative
 						value: "relative"
 						label: qsTr("Relative")
-						id: relative
+						info: qsTr("Each stack is rescaled so its total height equals 100 %")
 					}
 				}
 
-				// Use a GridLayout to arrange the two checkboxes side-by-side
 				GridLayout {
 					columns: 3
 					columnSpacing: 40
@@ -1260,96 +1617,47 @@ Form {
 					CheckBox {
 						name: "addBarStack"
 						label: qsTr("Bar stack")
-						info: qsTr("Add a bar stack to the plot. The mode (absolute or relative) is set by the Proportion Mode above.")
-						enabled: (
-									 // noRM :
-									 ( noRM.checked &&
-									  ((variableXPlotBuilder.count > 0 || variableYPlotBuilder.count > 0) && variableColorPlotBuilder.count > 0)
-									  )
-									 ||
-									 // yesRM :
-									 ((yesRM.checked && repeatedMeasuresFactors.count > 0) && groupVarRM.count > 0
-									  )
-									 )
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-						// Nested parameters
-						DoubleField {
-							name: "alphaBarStack"
-							label: qsTr("Transparency")
-							defaultValue: 0.8
-							min: 0
-							max: 1
-						}
-						CheckBox {
-							name: "reverseBarStack"
-							label: qsTr("Reverse order")
-							checked: false
-						}
+						info: qsTr("Add stacked bars for each category using the selected proportion mode")
+						enabled: ( noRM.checked &&
+								   (variableXPlotBuilder.count > 0 || variableYPlotBuilder.count > 0) &&
+								   variableColorPlotBuilder.count > 0 )
+							  || ( yesRM.checked &&
+								   repeatedMeasuresFactors.count > 0 &&
+								   groupVarRM.count > 0 )
+						onEnabledChanged: { if (!enabled) checked = false }
+
+						DoubleField { name: "alphaBarStack";   label: qsTr("Transparency"); defaultValue: 0.8; min: 0; max: 1 }
+						CheckBox    { name: "reverseBarStack"; label: qsTr("Reverse order") }
 					}
 
 					CheckBox {
 						name: "addAreaStack"
 						label: qsTr("Area stack")
-						info: qsTr("Add an area stack to the plot. The mode (absolute or relative) is set by the Proportion Mode above.")
-						enabled: (
-									 // noRM :
-									 ( noRM.checked &&
-									  ((variableXPlotBuilder.count > 0 || variableYPlotBuilder.count > 0) && variableColorPlotBuilder.count > 0)
-									  )
-									 ||
-									 // yesRM :
-									 ((yesRM.checked && repeatedMeasuresFactors.count > 0) && groupVarRM.count > 0
-									  )
-									 )
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false
-							}
-						}
-						// Nested parameters
-						DoubleField {
-							name: "alphaAreaStack"
-							label: qsTr("Transparency")
-							defaultValue: 0.4
-							min: 0
-							max: 1
-						}
-						DoubleField {
-							name: "linewidthAreaStack"
-							label: qsTr("Line width")
-							defaultValue: 0.25
-							min: 0
-						}
-						CheckBox {
-							name: "reverseAreaStack"
-							label: qsTr("Reverse order")
-							checked: false
-						}
-						CheckBox {
-							name: "replaceNaAreaStack"
-							label: qsTr("Replace N/A")
-							checked: false
-						}
+						info: qsTr("Add stacked areas connected across categories")
+						enabled: ( noRM.checked &&
+								   (variableXPlotBuilder.count > 0 || variableYPlotBuilder.count > 0) &&
+								   variableColorPlotBuilder.count > 0 )
+							  || ( yesRM.checked &&
+								   repeatedMeasuresFactors.count > 0 &&
+								   groupVarRM.count > 0 )
+						onEnabledChanged: { if (!enabled) checked = false }
+
+						DoubleField { name: "alphaAreaStack";     label: qsTr("Transparency"); defaultValue: 0.4; min: 0; max: 1 }
+						DoubleField { name: "linewidthAreaStack"; label: qsTr("Line width");  defaultValue: 0.25; min: 0 }
+						CheckBox    { name: "reverseAreaStack";   label: qsTr("Reverse order") }
+						CheckBox    { name: "replaceNaAreaStack"; label: qsTr("Replace N/A"); info: qsTr("Treat missing groups as a separate slice") }
 					}
 
 					CheckBox {
-						enabled: relative.checked
 						name: "asPercentage"
 						label: qsTr("Show as percentages")
-						checked: false
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false
-							}
-						}
+						enabled: relative.checked
+						info: qsTr("Format the relative scale from 0 % to 100 % instead of 0 to 1")
+						onEnabledChanged: { if (!enabled) checked = false }
 					}
-
 				}
 			}
+
 
 
 			// -------------------------------------------------------------------
@@ -1358,313 +1666,121 @@ Form {
 			Section {
 				title: qsTr("Mean")
 
+				info: qsTr("Summary layers that display the arithmetic mean of the Y variable for every X (or vice versa). "
+						 + "Requires both X and Y axes mapped. "
+						 + "Mean can be rendered as bar, line, dot, dash, area, or value. "
+						 + "Common controls: <b>Dodge</b> separates sub-groups, <b>Transparency</b> sets opacity, <b>Size/width</b> changes thickness, <b>Outline</b> toggles borders")
+
 				Label {
 					text: qsTr("Required: X AND Y-Axis Variables")
 					wrapMode: Text.Wrap
 					color: "black"
 				}
 
-
 				GridLayout {
 					columns: 3
 					rowSpacing: 40
 					columnSpacing: 40
 
-					// Mean bar
+					/* ── Mean bar ── */
 					CheckBox {
 						name: "addMeanBar"
 						label: qsTr("Mean bar")
-						info: qsTr("Enable to add a mean bar to the plot.")
-						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+						info: qsTr("Add mean bars")
+						enabled: (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+							   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+						onEnabledChanged: { if (!enabled) checked = false }
 
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeMeanBar"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "alphaMeanBar"
-							label: qsTr("Transparency")
-							defaultValue: 1
-							min: 0
-							max: 1
-						}
-						DoubleField {
-							name: "widthMeanBar"
-							label: qsTr("Bar width")
-							defaultValue: 0.8
-						}
+						DoubleField { name: "dodgeMeanBar";  label: qsTr("Dodge");        defaultValue: 0.8 }
+						DoubleField { name: "alphaMeanBar";  label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
+						DoubleField { name: "widthMeanBar";  label: qsTr("Bar width");    defaultValue: 0.8 }
 					}
 
-					// Mean dash
+					/* ── Mean dash ── */
 					CheckBox {
 						name: "addMeanDash"
 						label: qsTr("Mean dash")
-						info: qsTr("Enable to add dashed mean lines to the plot.")
-						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+						info: qsTr("Add dashed mean lines")
+						enabled: (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+							   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+						onEnabledChanged: { if (!enabled) checked = false }
 
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeMeanDash"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "dashwidthMeanDash"
-							label: qsTr("Dash width")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "linewidthMeanDash"
-							label: qsTr("Line width")
-							defaultValue: 1
-						}
-						DoubleField {
-							name: "alphaMeanDash"
-							label: qsTr("Transparency")
-							defaultValue: 1
-							min: 0
-							max: 1
-						}
-
-						CheckBox {
-							name: "blackOutlineMeanDash"
-							label: qsTr("Black dash")
-						}
+						DoubleField { name: "dodgeMeanDash";     label: qsTr("Dodge");       defaultValue: 0.8 }
+						DoubleField { name: "dashwidthMeanDash"; label: qsTr("Dash width");  defaultValue: 0.8 }
+						DoubleField { name: "linewidthMeanDash"; label: qsTr("Line width");  defaultValue: 1 }
+						DoubleField { name: "alphaMeanDash";     label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
+						CheckBox    { name: "blackOutlineMeanDash"; label: qsTr("Black dash") }
 					}
 
-					// Mean dot
+					/* ── Mean dot ── */
 					CheckBox {
 						name: "addMeanDot"
 						label: qsTr("Mean dot")
-						info: qsTr("Enable to add mean dots to the plot.")
-						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+						info: qsTr("Add mean dots")
+						enabled: (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+							   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+						onEnabledChanged: { if (!enabled) checked = false }
 
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeMeanDot"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "sizeMeanDot"
-							label: qsTr("Dot size")
-							defaultValue: 5
-						}
-						DoubleField {
-							name: "alphaMeanDot"
-							label: qsTr("Transparency")
-							defaultValue: 1
-							min: 0
-							max: 1
-						}
-
-						CheckBox {
-							name: "blackOutlineMeanDot"
-							label: qsTr("Black outline")
-						}
+						DoubleField { name: "dodgeMeanDot"; label: qsTr("Dodge");    defaultValue: 0.8 }
+						DoubleField { name: "sizeMeanDot";  label: qsTr("Dot size"); defaultValue: 5 }
+						DoubleField { name: "alphaMeanDot"; label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
+						CheckBox    { name: "blackOutlineMeanDot"; label: qsTr("Black outline") }
+						CheckBox    { name: "whiteOutlineMeanDot"; label: qsTr("White outline") }
 					}
 
-					// Mean line
+					/* ── Mean line ── */
 					CheckBox {
 						name: "addMeanLine"
 						label: qsTr("Mean line")
-						info: qsTr("Enable to add mean lines to the plot.")
-						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+						info: qsTr("Add mean profile lines")
+						enabled: (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+							   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+						onEnabledChanged: { if (!enabled) checked = false }
 
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeMeanLine"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "linewidthMeanLine"
-							label: qsTr("Line width")
-							defaultValue: 1
-						}
-						DoubleField {
-							name: "alphaMeanLine"
-							label: qsTr("Transparency")
-							defaultValue: 1
-							min: 0
-							max: 1
-						}
-
-						CheckBox {
-							name: "blackOutlineMeanLine"
-							label: qsTr("Black line")
-						}
+						DoubleField { name: "dodgeMeanLine";   label: qsTr("Dodge");      defaultValue: 0.8 }
+						DoubleField { name: "linewidthMeanLine"; label: qsTr("Line width"); defaultValue: 1 }
+						DoubleField { name: "alphaMeanLine";   label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
+						CheckBox    { name: "blackOutlineMeanLine"; label: qsTr("Black line") }
 					}
 
-					// Mean area
+					/* ── Mean area ── */
 					CheckBox {
 						name: "addMeanArea"
 						label: qsTr("Mean area")
-						info: qsTr("Enable to add mean areas to the plot.")
-						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+						info: qsTr("Add filled mean areas")
+						enabled: (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+							   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+						onEnabledChanged: { if (!enabled) checked = false }
 
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeMeanArea"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-
-						DoubleField {
-							name: "alphaMeanArea"
-							label: qsTr("Transparency")
-							defaultValue: 1
-							min: 0
-							max: 1
-						}
-
+						DoubleField { name: "dodgeMeanArea"; label: qsTr("Dodge");        defaultValue: 0.8 }
+						DoubleField { name: "alphaMeanArea"; label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
 					}
 
-					// Mean value
+					/* ── Mean value ── */
 					CheckBox {
 						name: "addMeanValue"
 						label: qsTr("Mean value")
-						info: qsTr("Enable to add mean values to the plot.")
-						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+						info: qsTr("Add numeric mean labels")
+						enabled: (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+							   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+						onEnabledChanged: { if (!enabled) checked = false }
 
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "fontsizeMeanValue"
-							label: qsTr("Font size")
-							defaultValue: 14
-						}
+						DoubleField  { name: "fontsizeMeanValue";  label: qsTr("Font size"); defaultValue: 14 }
 						FormulaField {
 							name: "accuracyMeanValue"
 							label: qsTr("Accuracy")
+							info: qsTr("Sets the rounding increment for the mean value; 0.1 gives one decimal, 0.01 gives two")
 							defaultValue: "0.1"
 						}
-						DoubleField {
-							name: "alphaMeanValue"
-							label: qsTr("Transparency")
-							defaultValue: 1
-							min: 0
-							max: 1
-						}
-						DoubleField {
-							name: "hjustMeanValue"
-							label: qsTr("Horizontal justification")
-							defaultValue: 0.5
-							min: -Infinity
-
-						}
-						DoubleField {
-							name: "vjustMeanValue"
-							label: qsTr("Vertical justification")
-							defaultValue: -0.5
-							min: -Infinity
-						}
-
-						CheckBox {
-							name: "blackOutlineMeanValue"
-							label: qsTr("Black text")
-						}
+						DoubleField  { name: "alphaMeanValue";     label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
+						DoubleField  { name: "hjustMeanValue";     label: qsTr("Horizontal justification"); defaultValue: 0.5; min: -Infinity }
+						DoubleField  { name: "vjustMeanValue";     label: qsTr("Vertical justification");   defaultValue: -0.5; min: -Infinity }
+						CheckBox     { name: "blackOutlineMeanValue"; label: qsTr("Black text") }
 					}
 				}
 			}
+
+
 
 			// -------------------------------------------------------------------
 			// Median
@@ -1672,6 +1788,11 @@ Form {
 			Section {
 				title: qsTr("Median")
 
+				info: qsTr("Summary layers that display the median of the Y variable for every X (or vice versa). "
+						 + "Requires both X and Y axes mapped. "
+						 + "Median can be rendered as bar, line, dot, dash, area, or value. "
+						 + "Common controls: <b>Dodge</b> separates sub-groups, <b>Transparency</b> sets opacity, <b>Size/width</b> changes thickness, <b>Outline</b> toggles borders")
+
 				Label {
 					text: qsTr("Required: X AND Y-Axis Variables")
 					wrapMode: Text.Wrap
@@ -1683,311 +1804,131 @@ Form {
 					rowSpacing: 40
 					columnSpacing: 40
 
-					// Median bar
+					/* Median bar ---------------------------------------------------- */
 					CheckBox {
 						name: "addMedianBar"
 						label: qsTr("Median bar")
-						info: qsTr("Enable to add a median bar to the plot.")
+						info: qsTr("Add median bars")
 						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
 									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+								  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+								 )
+						onEnabledChanged: { if (!enabled) checked = false }
 
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeMedianBar"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "alphaMedianBar"
-							label: qsTr("Transparency")
-							defaultValue: 1
-							min: 0
-							max: 1
-						}
-						DoubleField {
-							name: "widthMedianBar"
-							label: qsTr("Bar width")
-							defaultValue: 0.8
-
-						}
+						DoubleField { name: "dodgeMedianBar";  label: qsTr("Dodge");        defaultValue: 0.8 }
+						DoubleField { name: "alphaMedianBar";  label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
+						DoubleField { name: "widthMedianBar";  label: qsTr("Bar width");    defaultValue: 0.8 }
 					}
 
-					// Median dash
+					/* Median dash --------------------------------------------------- */
 					CheckBox {
 						id: addMedianDash
 						name: "addMedianDash"
 						label: qsTr("Median dash")
-						info: qsTr("Enable to add dashed median lines to the plot.")
+						info: qsTr("Add dashed median lines")
 						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
 									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+								  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+								 )
+						onEnabledChanged: { if (!enabled) checked = false }
 
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeMedianDash"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "dashwidthMedianDash"
-							label: qsTr("Dash width")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "linewidthMedianDash"
-							label: qsTr("Line width")
-							defaultValue: 1
-						}
-						DoubleField {
-							name: "alphaMedianDash"
-							label: qsTr("Transparency")
-							defaultValue: 1
-							min: 0
-							max: 1
-						}
-
-						CheckBox {
-							name: "blackOutlineMedianDash"
-							label: qsTr("Black dash")
-							enabled: addMedianDash.checked
-						}
+						DoubleField { name: "dodgeMedianDash";     label: qsTr("Dodge");       defaultValue: 0.8 }
+						DoubleField { name: "dashwidthMedianDash"; label: qsTr("Dash width");  defaultValue: 0.8 }
+						DoubleField { name: "linewidthMedianDash"; label: qsTr("Line width");  defaultValue: 1 }
+						DoubleField { name: "alphaMedianDash";     label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
+						CheckBox    { name: "blackOutlineMedianDash"; label: qsTr("Black dash"); enabled: addMedianDash.checked }
 					}
 
-					// Median dot
+					/* Median dot ---------------------------------------------------- */
 					CheckBox {
-						id:	addMedianDot
+						id: addMedianDot
 						name: "addMedianDot"
 						label: qsTr("Median dot")
-						info: qsTr("Enable to add median dots to the plot.")
+						info: qsTr("Add median dots")
 						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
 									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+								  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+								 )
+						onEnabledChanged: { if (!enabled) checked = false }
 
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-						DoubleField {
-							name: "dodgeMedianDot"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "sizeMedianDot"
-							label: qsTr("Dot size")
-							defaultValue: 5
-						}
-						DoubleField {
-							name: "alphaMedianDot"
-							label: qsTr("Transparency")
-							defaultValue: 1
-							min: 0
-							max: 1
-						}
-
-						CheckBox {
-							name: "blackOutlineMedianDot"
-							label: qsTr("Black outline")
-							enabled: addMedianDot.checked
-						}
+						DoubleField { name: "dodgeMedianDot"; label: qsTr("Dodge");    defaultValue: 0.8 }
+						DoubleField { name: "sizeMedianDot";  label: qsTr("Dot size"); defaultValue: 5 }
+						DoubleField { name: "alphaMedianDot"; label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
+						CheckBox    { name: "blackOutlineMedianDot"; label: qsTr("Black outline"); enabled: addMedianDot.checked }
+						CheckBox    { name: "whiteOutlineMedianDot"; label: qsTr("White outline") }
 					}
 
-					// Median line
+					/* Median line --------------------------------------------------- */
 					CheckBox {
 						id: addMedianLine
 						name: "addMedianLine"
 						label: qsTr("Median line")
-						info: qsTr("Enable to add median lines to the plot.")
+						info: qsTr("Add median profile lines")
 						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
 									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+								  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+								 )
+						onEnabledChanged: { if (!enabled) checked = false }
 
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeMedianLine"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "linewidthMedianLine"
-							label: qsTr("Line width")
-							defaultValue: 1
-						}
-						DoubleField {
-							name: "alphaMedianLine"
-							label: qsTr("Transparency")
-							defaultValue: 1
-							min: 0
-							max: 1
-						}
-
-						CheckBox {
-							name: "blackOutlineMedianLine"
-							label: qsTr("Black line")
-							enabled: addMedianLine.checked
-						}
+						DoubleField { name: "dodgeMedianLine";   label: qsTr("Dodge");      defaultValue: 0.8 }
+						DoubleField { name: "linewidthMedianLine"; label: qsTr("Line width"); defaultValue: 1 }
+						DoubleField { name: "alphaMedianLine";   label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
+						CheckBox    { name: "blackOutlineMedianLine"; label: qsTr("Black line"); enabled: addMedianLine.checked }
 					}
 
-					// Median area
+					/* Median area --------------------------------------------------- */
 					CheckBox {
 						name: "addMedianArea"
 						label: qsTr("Median area")
-						info: qsTr("Enable to add median areas to the plot.")
+						info: qsTr("Add filled median areas")
 						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
 									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+								  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+								 )
+						onEnabledChanged: { if (!enabled) checked = false }
 
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeMedianArea"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-
-						DoubleField {
-							name: "alphaMedianArea"
-							label: qsTr("Transparency")
-							defaultValue: 1
-							min: 0
-							max: 1
-						}
-
+						DoubleField { name: "dodgeMedianArea"; label: qsTr("Dodge");        defaultValue: 0.8 }
+						DoubleField { name: "alphaMedianArea"; label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
 					}
 
-					// Median value
+					/* Median value -------------------------------------------------- */
 					CheckBox {
 						name: "addMedianValue"
 						label: qsTr("Median value")
-						info: qsTr("Enable to add median values to the plot.")
+						info: qsTr("Add numeric median labels")
 						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
 									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+								  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+								 )
+						onEnabledChanged: { if (!enabled) checked = false }
 
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "fontsizeMedianValue"
-							label: qsTr("Font size")
-							defaultValue: 14
-						}
+						DoubleField  { name: "fontsizeMedianValue";  label: qsTr("Font size"); defaultValue: 14 }
 						FormulaField {
 							name: "accuracyMedianValue"
 							label: qsTr("Accuracy")
+							info: qsTr("Sets the rounding increment for the median value; 0.1 gives one decimal, 0.01 gives two")
 							defaultValue: "0.1"
 						}
-						DoubleField {
-							name: "alphaMedianValue"
-							label: qsTr("Transparency")
-							defaultValue: 1
-							min: 0
-							max: 1
-						}
-						DoubleField {
-							name: "hjustMedianValue"
-							label: qsTr("Horizontal justification")
-							defaultValue: 0.5
-							min: -Infinity
-						}
-						DoubleField {
-							name: "vjustMedianValue"
-							label: qsTr("Vertical justification")
-							defaultValue: -0.5
-							min: -Infinity
-						}
-
-						CheckBox {
-							name: "blackOutlineMedianValue"
-							label: qsTr("Black text")
-						}
+						DoubleField  { name: "alphaMedianValue";     label: qsTr("Transparency"); defaultValue: 1; min: 0; max: 1 }
+						DoubleField  { name: "hjustMedianValue";     label: qsTr("Horizontal justification"); defaultValue: 0.5; min: -Infinity }
+						DoubleField  { name: "vjustMedianValue";     label: qsTr("Vertical justification");   defaultValue: -0.5; min: -Infinity }
+						CheckBox     { name: "blackOutlineMedianValue"; label: qsTr("Black text") }
 					}
 				}
 			}
 
+
 			// -------------------------------------------------------------------
 			// Error bars and ribbons (range, sd, sem, 95% CI)
 			// -------------------------------------------------------------------
+
 			Section {
 				title: qsTr("Error bars and ribbons (range, SD, SEM, 95% CI)")
+
+				info: qsTr("Shows variability with vertical bars or shaded ribbons. "
+						 + "Choose <b>Range</b> (min–max), <b>SD</b>, <b>SEM</b>, or <b>95 % CI</b>. "
+						 + "Common controls: <b>Dodge</b> offsets overlapping groups, <b>Width/Line width</b> adjusts thickness, "
+						 + "<b>Transparency</b> sets opacity, <b>Black lines</b> toggles outlines")
 
 				Label {
 					text: qsTr("Required: X AND Y-Axis Variables")
@@ -2007,212 +1948,78 @@ Form {
 					rowSpacing: 40
 					columnSpacing: 70
 
-					// Range Error Bar
+					/* Range Error Bar */
 					CheckBox {
 						name: "addRangeErrorBar"
 						label: qsTr("Range error bar")
-						info: qsTr("Enable to add range error bars to the plot.")
+						info: qsTr("Add range error bars")
 						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+									  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+								   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+								 )
+						onEnabledChanged: { if (!enabled) checked = false }
 
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeRangeErrorBar"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "widthRangeErrorBar"
-							label: qsTr("Width")
-							defaultValue: 0.3
-						}
-						DoubleField {
-							name: "linewidthRangeErrorBar"
-							label: qsTr("Line width")
-							defaultValue: 1
-						}
-						DoubleField {
-							name: "transparencyRangeErrorBar"
-							label: qsTr("Transparency")
-							defaultValue: 1
-						}
-
-						CheckBox {
-							name: "blackOutlineRangeErrorBar"
-							label: qsTr("Black lines")
-						}
+						DoubleField { name: "dodgeRangeErrorBar";   label: qsTr("Dodge");        defaultValue: 0.8 }
+						DoubleField { name: "widthRangeErrorBar";   label: qsTr("Width");        defaultValue: 0.3 }
+						DoubleField { name: "linewidthRangeErrorBar"; label: qsTr("Line width"); defaultValue: 1 }
+						DoubleField { name: "transparencyRangeErrorBar"; label: qsTr("Transparency"); defaultValue: 1 }
+						CheckBox    { name: "blackOutlineRangeErrorBar"; label: qsTr("Black lines") }
 					}
 
-					// SD Error Bar
+					/* SD Error Bar */
 					CheckBox {
 						id: addSDErrorBar
 						name: "addSDErrorBar"
 						label: qsTr("SD error bar")
-						info: qsTr("Enable to add standard deviation error bars to the plot.")
+						info: qsTr("Add SD error bars")
 						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+									  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+								   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+								 )
+						onEnabledChanged: { if (!enabled) checked = false }
 
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeSDErrorBar"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "widthSDErrorBar"
-							label: qsTr("Width")
-							defaultValue: 0.3
-						}
-						DoubleField {
-							name: "linewidthSDErrorBar"
-							label: qsTr("Line width")
-							defaultValue: 1
-						}
-						DoubleField {
-							name: "transparencySDErrorBar"
-							label: qsTr("Transparency")
-							defaultValue: 1
-						}
-
-						CheckBox {
-							name: "blackOutlineSDErrorBar"
-							label: qsTr("Black lines")
-							enabled: addSDErrorBar.checked
-						}
+						DoubleField { name: "dodgeSDErrorBar";   label: qsTr("Dodge");        defaultValue: 0.8 }
+						DoubleField { name: "widthSDErrorBar";   label: qsTr("Width");        defaultValue: 0.3 }
+						DoubleField { name: "linewidthSDErrorBar"; label: qsTr("Line width"); defaultValue: 1 }
+						DoubleField { name: "transparencySDErrorBar"; label: qsTr("Transparency"); defaultValue: 1 }
+						CheckBox    { name: "blackOutlineSDErrorBar"; label: qsTr("Black lines"); enabled: addSDErrorBar.checked }
 					}
 
-					// SEM Error Bar
+					/* SEM Error Bar */
 					CheckBox {
 						id: addSEMErrorBar
 						name: "addSEMErrorBar"
 						label: qsTr("SEM error bar")
-						info: qsTr("Enable to add SEM error bars to the plot.")
+						info: qsTr("Add SEM error bars")
 						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+									  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+								   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+								 )
+						onEnabledChanged: { if (!enabled) checked = false }
 
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeSEMErrorBar"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "widthSEMErrorBar"
-							label: qsTr("Width")
-							defaultValue: 0.3
-						}
-						DoubleField {
-							name: "linewidthSEMErrorBar"
-							label: qsTr("Line width")
-							defaultValue: 1
-						}
-						DoubleField {
-							name: "transparencySEMErrorBar"
-							label: qsTr("Transparency")
-							defaultValue: 1
-						}
-
-						CheckBox {
-							name: "blackOutlineSEMErrorBar"
-							label: qsTr("Black lines")
-							enabled: addSEMErrorBar.checked
-						}
+						DoubleField { name: "dodgeSEMErrorBar";   label: qsTr("Dodge");        defaultValue: 0.8 }
+						DoubleField { name: "widthSEMErrorBar";   label: qsTr("Width");        defaultValue: 0.3 }
+						DoubleField { name: "linewidthSEMErrorBar"; label: qsTr("Line width"); defaultValue: 1 }
+						DoubleField { name: "transparencySEMErrorBar"; label: qsTr("Transparency"); defaultValue: 1 }
+						CheckBox    { name: "blackOutlineSEMErrorBar"; label: qsTr("Black lines"); enabled: addSEMErrorBar.checked }
 					}
 
-					// 95% CI Error Bar
+					/* 95 % CI Error Bar */
 					CheckBox {
 						name: "addCI95ErrorBar"
-						label: qsTr("95% CI Error Bar")
-						info: qsTr("Enable to add 95% confidence interval error bars to the plot.")
+						label: qsTr("95% CI error bar")
+						info: qsTr("Add 95 % CI error bars")
 						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+									  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+								   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+								 )
+						onEnabledChanged: { if (!enabled) checked = false }
 
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "dodgeCI95ErrorBar"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-						}
-						DoubleField {
-							name: "widthCI95ErrorBar"
-							label: qsTr("Width")
-							defaultValue: 0.3
-						}
-						DoubleField {
-							name: "linewidthCI95ErrorBar"
-							label: qsTr("Line width")
-							defaultValue: 1
-						}
-						DoubleField {
-							name: "transparencyCI95ErrorBar"
-							label: qsTr("Transparency")
-							defaultValue: 1
-						}
-
-						CheckBox {
-							name: "blackOutlineCI95ErrorBar"
-							label: qsTr("Black lines")
-						}
+						DoubleField { name: "dodgeCI95ErrorBar";   label: qsTr("Dodge");        defaultValue: 0.8 }
+						DoubleField { name: "widthCI95ErrorBar";   label: qsTr("Width");        defaultValue: 0.3 }
+						DoubleField { name: "linewidthCI95ErrorBar"; label: qsTr("Line width"); defaultValue: 1 }
+						DoubleField { name: "transparencyCI95ErrorBar"; label: qsTr("Transparency"); defaultValue: 1 }
+						CheckBox    { name: "blackOutlineCI95ErrorBar"; label: qsTr("Black lines") }
 					}
 				}
 
@@ -2221,161 +2028,69 @@ Form {
 					rowSpacing: 40
 					columnSpacing: 70
 
-					// Range Ribbon
+					/* Range Ribbon */
 					CheckBox {
 						name: "addRangeRibbon"
 						label: qsTr("Range ribbon")
-						info: qsTr("Enable to add a range ribbon to the plot.")
+						info: qsTr("Add range ribbons")
 						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+									  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+								   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+								 )
+						onEnabledChanged: { if (!enabled) checked = false }
 
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "alphaRangeRibbon"
-							label: qsTr("Transparency")
-							defaultValue: 0.4
-							min: 0
-							max: 1
-						}
-
-						// Black outline/fill
-						CheckBox {
-							name: "blackOutlineRangeRibbon"
-							label: qsTr("Black lines")
-						}
+						DoubleField { name: "alphaRangeRibbon"; label: qsTr("Transparency"); defaultValue: 0.4; min: 0; max: 1 }
+						CheckBox    { name: "blackOutlineRangeRibbon"; label: qsTr("Black lines") }
 					}
 
-					// SD Ribbon
+					/* SD Ribbon */
 					CheckBox {
 						id: addSdRibbon
 						name: "addSdRibbon"
 						label: qsTr("SD ribbon")
-						info: qsTr("Enable to add an SD ribbon to the plot.")
+						info: qsTr("Add SD ribbons")
 						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+									  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+								   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+								 )
+						onEnabledChanged: { if (!enabled) checked = false }
 
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "alphaSdRibbon"
-							label: qsTr("Transparency")
-							defaultValue: 0.4
-							min: 0
-							max: 1
-						}
-
-						CheckBox {
-							name: "blackOutlineSdRibbon"
-							label: qsTr("Black lines")
-							enabled: addSdRibbon.checked
-						}
+						DoubleField { name: "alphaSdRibbon"; label: qsTr("Transparency"); defaultValue: 0.4; min: 0; max: 1 }
+						CheckBox    { name: "blackOutlineSdRibbon"; label: qsTr("Black lines"); enabled: addSdRibbon.checked }
 					}
 
-					// SEM Ribbon
+					/* SEM Ribbon */
 					CheckBox {
 						name: "addSemRibbon"
 						label: qsTr("SEM ribbon")
-						info: qsTr("Enable to add a SEM ribbon to the plot.")
+						info: qsTr("Add SEM ribbons")
 						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+									  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+								   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+								 )
+						onEnabledChanged: { if (!enabled) checked = false }
 
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-										  xVarRM.count > 0
-
-										  ))
-									 )
-
-						onEnabledChanged:{
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "alphaSemRibbon"
-							label: qsTr("Transparency")
-							defaultValue: 0.4
-							min: 0
-							max: 1
-						}
-
-						CheckBox {
-							name: "blackOutlineSemRibbon"
-							label: qsTr("Black lines")
-						}
+						DoubleField { name: "alphaSemRibbon"; label: qsTr("Transparency"); defaultValue: 0.4; min: 0; max: 1 }
+						CheckBox    { name: "blackOutlineSemRibbon"; label: qsTr("Black lines") }
 					}
 
-					// 95% CI Ribbon
+					/* 95 % CI Ribbon */
 					CheckBox {
 						name: "addCi95Ribbon"
 						label: qsTr("95% CI ribbon")
-						info: qsTr("Enable to add a 95% confidence interval ribbon to the plot.")
+						info: qsTr("Add 95 % CI ribbons")
 						enabled: (
-									 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
-									 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+									  (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
+								   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+								 )
+						onEnabledChanged: { if (!enabled) checked = false }
 
-									 ||
-
-									 // 2. If repeated measures (yesRM) and at least one of the following is true:
-									 (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-
-									 )
-
-						onEnabledChanged: {
-							if (!enabled) {
-								checked = false;
-							}
-						}
-
-						DoubleField {
-							name: "alphaCi95Ribbon"
-							label: qsTr("Transparency")
-							defaultValue: 0.4
-							min: 0
-							max: 1
-						}
-
-						CheckBox {
-							name: "blackOutlineCi95Ribbon"
-							label: qsTr("Black lines")
-						}
+						DoubleField { name: "alphaCi95Ribbon"; label: qsTr("Transparency"); defaultValue: 0.4; min: 0; max: 1 }
+						CheckBox    { name: "blackOutlineCi95Ribbon"; label: qsTr("Black lines") }
 					}
 				}
 			}
+
 
 			// -------------------------------------------------------------------
 			// Curve fit and reference lines
@@ -2383,6 +2098,10 @@ Form {
 			Section {
 				title: qsTr("Curve fit and reference lines")
 
+				info: qsTr("Fit trend lines or statistical models and add reference or identity lines for comparison. "
+						 + "Curve fitting requires individual data points. "
+						 + "Common controls: <b>Method</b> chooses the model, <b>Line width</b> adjusts thickness, "
+						 + "<b>Dodge</b> separates groups, <b>Transparency</b> sets opacity, and <b>Color</b> selects the line colour")
 
 				Label {
 					text: qsTr("Required: individual data points (Curve fit)")
@@ -2390,18 +2109,12 @@ Form {
 					color: "black"
 				}
 
-
 				CheckBox {
 					name: "addCurveFitPlotBuilder"
 					label: qsTr("Add curve fit")
-					info: "With this option you can fit a model on the data points."
+					info: qsTr("Fit a model to the data points")
 					enabled: addDataPoint.checked
-					onEnabledChanged: {
-						if (!enabled) {
-							checked = false;
-						}
-					}
-
+					onEnabledChanged: { if (!enabled) checked = false }
 					columns: 3
 
 					Group {
@@ -2411,11 +2124,10 @@ Form {
 							id: curvaFitMethod
 							indexDefaultValue: 0
 							values: [
-								{label: qsTr("Linear"), value: "lm"},
-								{label: qsTr("LOESS"), value: "loess"}
+								{ label: qsTr("Linear"), value: "lm" },
+								{ label: qsTr("LOESS"),  value: "loess" }
 							]
 						}
-
 						DoubleField {
 							name: "linewidthCurveFit"
 							label: qsTr("Line width")
@@ -2424,85 +2136,38 @@ Form {
 					}
 
 					Group {
-						DoubleField {
-							name: "dodgeCurveFit"
-							label: qsTr("Dodge")
-							defaultValue: 0.8
-							min: 0
-							max: 1
-						}
-						DoubleField {
-							name: "transparencyCurveFit"
-							label: qsTr("Transparency")
-							defaultValue: 0.2
-							min: 0
-							max: 1
-						}
+						DoubleField { name: "dodgeCurveFit";        label: qsTr("Dodge");        defaultValue: 0.8; min: 0; max: 1 }
+						DoubleField { name: "transparencyCurveFit"; label: qsTr("Transparency"); defaultValue: 0.2; min: 0; max: 1 }
 					}
 
 					Group {
-						CheckBox {
-							name: "seCurveFit"
-							label: qsTr("SE")
-							checked: true
-						}
-						CheckBox {
-							name: "blackOutlineCurveFit"
-							label: qsTr("Black lines")
-						}
+						CheckBox { name: "seCurveFit";           label: qsTr("SE");          checked: true }
+						CheckBox { name: "blackOutlineCurveFit"; label: qsTr("Black lines") }
 					}
-
-
 				}
 
 				CheckBox {
 					name: "addReferenceLinePlotBuilder"
 					label: qsTr("Add reference line")
-					info: "Add reference lines."
+					info: qsTr("Add reference lines")
 					columns: 2
 
 					Group {
-						TextField {
-							name: "xReferenceLine"
-							label: qsTr("X-axis intercept")
-							placeholderText: qsTr("e.g. 0.5, or c(1,2)")
-							fieldWidth: 100
-						}
-
-						TextField {
-							name: "yReferenceLine"
-							label: qsTr("Y-axis intercept")
-							placeholderText: qsTr("e.g. 0.5, or c(1,2)")
-							fieldWidth: 100
-						}
+						TextField { name: "xReferenceLine"; label: qsTr("X-axis intercept"); placeholderText: qsTr("e.g. 0.5, or c(1,2)"); fieldWidth: 100 }
+						TextField { name: "yReferenceLine"; label: qsTr("Y-axis intercept"); placeholderText: qsTr("e.g. 0.5, or c(1,2)"); fieldWidth: 100 }
 					}
 
 					Group {
-						DoubleField {
-							name: "linewidhtReferenceLines"
-							label: qsTr("Line width")
-							defaultValue: 1
-						}
-
-						TextField {
-							name: "colorReferenceLine"
-							label: qsTr("Line color")
-							placeholderText: qsTr("e.g. black, #ff5733")
-							defaultValue: "lightgray"
-							fieldWidth: 100
-						}
+						DoubleField { name: "linewidhtReferenceLines"; label: qsTr("Line width"); defaultValue: 1 }
+						TextField   { name: "colorReferenceLine";      label: qsTr("Line color"); placeholderText: qsTr("e.g. black, #ff5733"); defaultValue: "lightgray"; fieldWidth: 100 }
 
 						Label {
-							text: qsTr("Note: For available colors, see %1 this page %2").arg("<a href='https://r-charts.com/colors/' style='color: blue; text-decoration: underline;'>").arg("</a>.")
+							text: qsTr("Note: For available colors, see %1this page%2")
+								  .arg("<a href='https://r-charts.com/colors/' style='color: blue; text-decoration: underline;'>")
+								  .arg("</a>")
 							wrapMode: Text.Wrap
 							textFormat: Text.RichText
-
-							MouseArea {
-								anchors.fill: parent
-								onClicked: {
-									Qt.openUrlExternally("https://r-charts.com/colors/")
-								}
-							}
+							MouseArea { anchors.fill: parent; onClicked: { Qt.openUrlExternally("https://r-charts.com/colors/") } }
 						}
 					}
 				}
@@ -2510,39 +2175,24 @@ Form {
 				CheckBox {
 					name: "addIdentityLinePlotBuilder"
 					label: qsTr("Add identity line")
-					info: "Add identity line (y = x)."
-
-					CheckBox{
-						name: "reversedirectionIdentityLine"
-						label: "Reverse direction"
-					}
-
+					info: qsTr("Add identity line (y = x)")
+					CheckBox { name: "reversedirectionIdentityLine"; label: qsTr("Reverse direction") }
 					TextField {
-						name: "colorIdentityLine"
-						label: qsTr("Line color")
-						placeholderText: qsTr("e.g. black, #ff5733")
-						defaultValue: "lightgray"
-						fieldWidth: 100
+						name: "colorIdentityLine"; label: qsTr("Line color");
+						placeholderText: qsTr("e.g. black, #ff5733"); defaultValue: "lightgray"; fieldWidth: 100
 					}
-
 				}
 
 				Label {
 					text: qsTr("Note: For available colors, see %1this page%2")
-					.arg("<a href='https://r-charts.com/colors/' style='color: blue; text-decoration: underline;'>")
-					.arg("</a>")
+						  .arg("<a href='https://r-charts.com/colors/' style='color: blue; text-decoration: underline;'>")
+						  .arg("</a>")
 					wrapMode: Text.Wrap
 					textFormat: Text.RichText
-
-					MouseArea {
-						anchors.fill: parent
-						onClicked: {
-							Qt.openUrlExternally("https://r-charts.com/colors/")
-						}
-					}
+					MouseArea { anchors.fill: parent; onClicked: { Qt.openUrlExternally("https://r-charts.com/colors/") } }
 				}
-
 			}
+
 
 			Label {
 				text: qsTr("Axis settings and annotations")
@@ -2556,79 +2206,54 @@ Form {
 			// -------------------------------------------------------------------
 			Section {
 				columns: 3
+				title: qsTr("X-Axis")
 
-				title: qsTr("X-axis")
-
+				/* concise, section-level help */
+				info: qsTr("Fine-tune the x-axis: <b>Title</b> adds a heading, "
+						 + "<b>Limits</b> sets the range, <b>Breaks</b> positions tick marks, "
+						 + "<b>Labels</b> handle rotation, shortening and sorting, and "
+						 + "<b>Rename labels</b> lets you edit them manually")
 
 				TextField {
 					label: qsTr("Title")
 					name: "titleXPlotBuilder"
 					placeholderText: qsTr("Enter x-axis title")
-					fieldWidth: 300
-					info: qsTr("Specify the title for the x-axis")
+					fieldWidth: 300          /* per earlier code */
+					/* per request, no per-field info here */
 					Layout.columnSpan: 3
 				}
 
 				Group {
-					title:qsTr("Limits")
-					columns:1
-
-					TextField {
-						name: "limitFromX"
-						label: qsTr("From")
-						fieldWidth: 40
-					}
-
-					TextField {
-						name: "limitToX"
-						label: qsTr("To")
-						fieldWidth: 40
-					}
+					title: qsTr("Limits")
+					columns: 1
+					TextField { name: "limitFromX"; label: qsTr("From"); fieldWidth: 40 }
+					TextField { name: "limitToX";   label: qsTr("To");   fieldWidth: 40 }
 				}
 
 				Group {
-					title: "Breaks"
-					columns:1
-
-					TextField {
-						name: "breakFromX"
-						label: qsTr("From")
-						fieldWidth: 40
-					}
-
-					TextField {
-						name: "breakToX"
-						label: qsTr("To")
-						fieldWidth: 40
-					}
-
-					TextField {
-						name: "breakByX"
-						label: qsTr("By")
-						fieldWidth: 40
-					}
+					title: qsTr("Breaks")
+					columns: 1
+					TextField { name: "breakFromX"; label: qsTr("From"); fieldWidth: 40 }
+					TextField { name: "breakToX";   label: qsTr("To");   fieldWidth: 40 }
+					TextField { name: "breakByX";   label: qsTr("By");   fieldWidth: 40 }
 				}
 
 				Group {
 					columns: 1
 					title: qsTr("Labels")
-					CheckBox {
-						name: "rotateXLabel"
-						label: "Rotate"
-					}
+
+					CheckBox { name: "rotateXLa	bel"; label: qsTr("Rotate") }
 
 					CheckBox {
 						name: "cutShortScale"
 						label: qsTr("Shorten")
-						info: qsTr("Whether to shorten axis labels using K for thousand, M for million, and so on.")
+						info: qsTr("Shorten axis labels using K for thousand, M for million, and so on")
 					}
-
 
 					CheckBox {
 						name: "enableSort"
 						label: qsTr("Sort")
 						checked: false
-
 
 						DropDown {
 							name: "sortXLabelsOrder"
@@ -2636,7 +2261,6 @@ Form {
 							values: ["Increasing", "Decreasing"]
 							startValue: "Increasing"
 						}
-
 
 						DropDown {
 							name: "aggregationFun"
@@ -2653,16 +2277,8 @@ Form {
 					addItemManually: true
 					minimumItems: 0
 					rowComponent: Row {
-						TextField {
-							name: "originalXLabel"
-							label: qsTr("Original label")
-							fieldWidth: 100
-						}
-						TextField {
-							name: "newXLabel"
-							label: qsTr("New label")
-							fieldWidth: 150
-						}
+						TextField { name: "originalXLabel"; label: qsTr("Original label"); fieldWidth: 100 }
+						TextField { name: "newXLabel";      label: qsTr("New label");      fieldWidth: 150 }
 					}
 				}
 			}
@@ -2670,82 +2286,57 @@ Form {
 
 			Section {
 				columns: 3
+				title: qsTr("Y-Axis")
 
-				title: qsTr("Y-axis")
+				/* concise, section-level help */
+				info: qsTr("Fine-tune the y-axis: <b>Title</b> adds a heading, "
+						 + "<b>Limits</b> sets the range, <b>Breaks</b> positions tick marks, "
+						 + "<b>Labels</b> handle rotation, shortening and sorting, and "
+						 + "<b>Rename labels</b> lets you edit them manually")
 
 				TextField {
 					label: qsTr("Title")
 					name: "titleYPlotBuilder"
 					placeholderText: qsTr("Enter y-axis title")
 					fieldWidth: 300
-					info: qsTr("Specify the title for the Y-axis.")
 					Layout.columnSpan: 3
 				}
 
 				Group {
 					title: qsTr("Limits")
 					columns: 1
-
-					TextField {
-						name: "limitFromY"
-						label: qsTr("From")
-						fieldWidth: 40
-					}
-
-					TextField {
-						name: "limitToY"
-						label: qsTr("To")
-						fieldWidth: 40
-					}
+					TextField { name: "limitFromY"; label: qsTr("From"); fieldWidth: 40 }
+					TextField { name: "limitToY";   label: qsTr("To");   fieldWidth: 40 }
 				}
 
 				Group {
 					title: qsTr("Breaks")
 					columns: 1
-
-					TextField {
-						name: "breakFromY"
-						label: qsTr("From")
-						fieldWidth: 40
-					}
-
-					TextField {
-						name: "breakToY"
-						label: qsTr("To")
-						fieldWidth: 40
-					}
-
-					TextField {
-						name: "breakByY"
-						label: qsTr("By")
-						fieldWidth: 40
-					}
+					TextField { name: "breakFromY"; label: qsTr("From"); fieldWidth: 40 }
+					TextField { name: "breakToY";   label: qsTr("To");   fieldWidth: 40 }
+					TextField { name: "breakByY";   label: qsTr("By");   fieldWidth: 40 }
 				}
 
 				Group {
 					title: qsTr("Labels")
 					columns: 1
 
-					CheckBox {
-						name: "rotateYLabel"
-						label: qsTr("Rotate")
-					}
+					CheckBox { name: "rotateYLabel"; label: qsTr("Rotate") }
 
 					CheckBox {
 						name: "cutShortScaleY"
 						label: qsTr("Shorten")
-						info: qsTr("Whether to shorten axis labels using K for thousand, M for million, and so on.")
+						info: qsTr("Shorten axis labels using K for thousand, M for million, and so on")
 					}
 
-					// If you want to enable sorting on the Y axis:
 					CheckBox {
 						name: "enableSortY"
-						label: qsTr("Enable sorting")
+						label: qsTr("Sort")
 						checked: false
 
 						DropDown {
 							name: "sortYLabelsOrder"
-							label: qsTr("Sort")
+							label: qsTr("Order")
 							values: ["Increasing", "Decreasing"]
 							startValue: "Increasing"
 						}
@@ -2758,42 +2349,38 @@ Form {
 						}
 					}
 				}
+
 				ComponentsList {
 					name: "yAxisLabelRenamer"
 					title: qsTr("Rename labels")
 					addItemManually: true
 					minimumItems: 0
+
 					rowComponent: Row {
-						TextField {
-							name: "originalYLabel"
-							label: qsTr("Original label")
-							fieldWidth: 100
-						}
-						TextField {
-							name: "newYLabel"
-							label: qsTr("New label")
-							fieldWidth: 150
-						}
+						TextField { name: "originalYLabel"; label: qsTr("Original label"); fieldWidth: 100 }
+						TextField { name: "newYLabel";      label: qsTr("New label");      fieldWidth: 150 }
 					}
 				}
 			}
+
+
 
 			// -------------------------------------------------------------------
 			// Title, caption, annotation
 			// -------------------------------------------------------------------
 			Section {
-				title: qsTr("Title, caption, annotation")
-				columns:1
+				title: qsTr("Title, caption")
+				columns: 1
+
+				info: qsTr("Use these fields to add text to your figure. "
+						 + "<b>Title</b> appears above the plot, while <b>Caption</b> appears below")
 
 				Group {
-
-
 					TextField {
 						name: "titlePlotBuilder"
 						label: qsTr("Title")
 						placeholderText: qsTr("Enter the plot title here")
 						fieldWidth: 300
-
 					}
 				}
 
@@ -2802,31 +2389,80 @@ Form {
 					name: "captionPlotBuilder"
 					height: 100
 				}
+			}
+
+
+			Section {
+				text: qsTr("Annotation and data label")
+
+				info: qsTr("Label points automatically or place custom annotations anywhere. "
+						 + "<b>Label variable</b> shows each point’s value; <b>Custom annotations</b> add free-form text with position controls. "
+						 + "Common controls: <b>Size</b> adjusts text height, <b>White background</b> improves legibility, colour fields accept named or hex colours")
+
+				Label {
+					text: qsTr("Label data by variable")
+					wrapMode: Text.Wrap
+					color: "black"
+				}
+
+				VariablesForm {
+					enabled: addDataPoint.checked
+					preferredWidth: jaspForm.width - 2 * jaspTheme.contentMargin
+					preferredHeight: 100 * preferencesModel.uiScale
+
+					AvailableVariablesList {
+						name: "labelVars"
+						source: [
+							{ name: "allVariablesList",   use: ["type=scale","type=ordinal","type=nominal"] },
+							{ name: "allVariablesListRM", use: ["type=scale","type=ordinal","type=nominal"] }
+						]
+					}
+
+					AssignedVariablesList {
+						name:           "labelVariablePlotBuilder"
+						title:          qsTr("Label variable")
+						allowedColumns: ["scale","ordinal","nominal"]
+						singleVariable: true
+						enabled: addDataPoint.checked
+						onEnabledChanged: {
+							if (!enabled) {
+								while (count > 0) {
+									itemDoubleClicked(0)
+								}
+							}
+						}
+						info: qsTr("Variable whose values will be shown next to each point")
+					}
+
+					Group {
+						columns: 2
+						DoubleField {
+							name:  "fontsizeDataLabels"
+							label: qsTr("Size")
+							value: 4
+							fieldWidth: 50
+						}
+						CheckBox {
+							name:  "backgroundDataLabels"
+							label: qsTr("White background")
+							checked: false
+							Layout.fillWidth: false
+						}
+					}
+				}
 
 				ComponentsList {
 					name: "annotationPlotBuilder"
 					id: annotationPlotBuilder
-					title: qsTr("Annotations")
+					title: qsTr("Custom annotations")
 					addItemManually: true
 					minimumItems: 0
 					enabled: (
-								 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
-								 (noRM.checked && variableXPlotBuilder.count > 0 || variableYPlotBuilder.count > 0)
-
-								 ||
-
-								 // 2. If repeated measures (yesRM) and at least one of the following is true:
-								 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-									  (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
-
-
-									  )
-								  )
-								 )
+								  (noRM.checked && (variableXPlotBuilder.count > 0 || variableYPlotBuilder.count > 0))
+							   || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+							 )
 					onEnabledChanged: {
 						if (!enabled) {
-							// remove all components one by one
 							for (var i = annotationPlotBuilder.count - 1; i >= 0; --i) {
 								annotationPlotBuilder.removeItem(i)
 							}
@@ -2834,9 +2470,7 @@ Form {
 					}
 
 					rowComponent: Row {
-
 						Group {
-
 							title: qsTr("Annotation ") + (rowIndex + 1)
 							columns: 4
 
@@ -2851,7 +2485,6 @@ Form {
 							}
 
 							Group {
-
 								columns: 2
 								title: qsTr("Position")
 
@@ -2871,24 +2504,18 @@ Form {
 								}
 
 								Group {
-
 									DropDown {
 										visible: noRM.checked
 										name: "ColumnAnnotation"
 										label: qsTr("Column")
 										values: columnsvariableSplitPlotBuilder.levels
 										enabled: noRM.checked
-										onEnabledChanged: {
-											if (!enabled) {
-												currentIndex = -1
-											}
-										}
+										onEnabledChanged: { if (!enabled) currentIndex = -1 }
 									}
 
-									DropDown
-									{
-										name: "RMColumnAnnotation";
-										title: qsTr("Column");
+									DropDown {
+										name: "RMColumnAnnotation"
+										title: qsTr("Column")
 										visible: yesRM.checked
 										enabled: yesRM.checked
 										values: colSplitRM.columnsNames.length > 0
@@ -2898,14 +2525,8 @@ Form {
 												: []
 										addEmptyValue: groupValue.columnsNames.length === 0
 										placeholderText: qsTr("<No Value>")
-										onEnabledChanged: {
-											if (!enabled) {
-												currentIndex = -1
-											}
-										}
+										onEnabledChanged: { if (!enabled) currentIndex = -1 }
 									}
-
-
 
 									DropDown {
 										name: "RowAnnotation"
@@ -2913,17 +2534,12 @@ Form {
 										values: rowsvariableSplitPlotBuilder.levels
 										enabled: noRM.checked
 										visible: noRM.checked
-										onEnabledChanged: {
-											if (!enabled) {
-												currentIndex = -1
-											}
-										}
+										onEnabledChanged: { if (!enabled) currentIndex = -1 }
 									}
 
-									DropDown
-									{
-										name: "RMRowAnnotation";
-										title: qsTr("Row");
+									DropDown {
+										name: "RMRowAnnotation"
+										title: qsTr("Row")
 										visible: yesRM.checked
 										enabled: yesRM.checked
 										values: rowSplitRM.columnsNames.length > 0
@@ -2933,11 +2549,7 @@ Form {
 												: []
 										addEmptyValue: groupValue.columnsNames.length === 0
 										placeholderText: qsTr("<No Value>")
-										onEnabledChanged: {
-											if (!enabled) {
-												currentIndex = -1
-											}
-										}
+										onEnabledChanged: { if (!enabled) currentIndex = -1 }
 									}
 
 									DropDown {
@@ -2946,17 +2558,12 @@ Form {
 										values: gridVariablePlotBuilder.levels
 										enabled: noRM.checked
 										visible: noRM.checked
-										onEnabledChanged: {
-											if (!enabled) {
-												currentIndex = -1
-											}
-										}
+										onEnabledChanged: { if (!enabled) currentIndex = -1 }
 									}
 
-									DropDown
-									{
-										name: "RMGridAnnotation";
-										title: qsTr("Grid");
+									DropDown {
+										name: "RMGridAnnotation"
+										title: qsTr("Grid")
 										visible: yesRM.checked
 										enabled: yesRM.checked
 										values: gridVarRM.columnsNames.length > 0
@@ -2966,28 +2573,18 @@ Form {
 												: []
 										addEmptyValue: groupValue.columnsNames.length === 0
 										placeholderText: qsTr("<No Value>")
-										onEnabledChanged: {
-											if (!enabled) {
-												currentIndex = -1
-											}
-										}
+										onEnabledChanged: { if (!enabled) currentIndex = -1 }
 									}
-
-
 								}
-
-
 							}
 
 							Group {
-								title:qsTr("Appearance")
-
+								title: qsTr("Appearance")
 								DoubleField {
 									name: "annotationSize"
 									label: qsTr("Size")
 									defaultValue: 5.5
 								}
-
 								TextField {
 									name: "colorText"
 									label: qsTr("Color")
@@ -2995,15 +2592,12 @@ Form {
 									defaultValue: "black"
 									fieldWidth: 60
 								}
-
 							}
-
 						}
-
 					}
 				}
-
 			}
+
 
 
 			Label {
@@ -3017,6 +2611,12 @@ Form {
 			Section {
 				title: qsTr("Theme and color")
 
+				/* section-level help */
+				info: qsTr("Choose an overall visual style and how colours are assigned. "
+						 + "<b>Theme</b> applies a preset look, while <b>Font base size</b> scales all text. "
+						 + "<b>Color settings</b> lets you map colour to a variable, pick a palette, or enter custom colours")
+
+				/* ────────────────── Theme & font size ────────────────── */
 				Group {
 					columns: 2
 
@@ -3026,6 +2626,7 @@ Form {
 						values: ["JASP", "ggplotgray", "ggpubr", "PlotBuilder"]
 						indexDefaultValue: 0
 					}
+
 					DoubleField {
 						name: "baseFontSize"
 						label: qsTr("Font base size")
@@ -3033,64 +2634,70 @@ Form {
 					}
 				}
 
+				/* ────────────────── Colour mapping and palettes ────────────────── */
 				Group {
 					title: qsTr("Color settings")
+					info: qsTr("Decide which variable drives colours and select a palette or provide custom hex/named colours")
 					columns: 1
 
 					RadioButtonGroup {
 						name: "colorByGroup"
 						title: qsTr("Color by")
+						info: qsTr("Choose what determines element colours")
 						radioButtonsOnSameRow: true
 						columns: 4
 
 						RadioButton {
 							value: "none"
 							label: qsTr("None")
+							info: qsTr("Uniform colors")
 							enabled: true
 							checked: !colorXRadio.checked && !colorYRadio.checked
-							onEnabledChanged: { if (!enabled && checked) { checked = false; } }
+							onEnabledChanged: { if (!enabled && checked) checked = false }
 						}
 						RadioButton {
 							value: "grouping"
 							label: qsTr("Group variable")
+							info: qsTr("Coloring by Group variable")
 							enabled: variableColorPlotBuilder.count > 0 || groupVarRM.count > 0
 							checked: variableColorPlotBuilder.count > 0 || groupVarRM.count > 0
-							onEnabledChanged: { if (!enabled && checked) { checked = false; } }
+							onEnabledChanged: { if (!enabled && checked) checked = false }
 						}
 						RadioButton {
 							id: colorXRadio
 							value: "x"
 							label: qsTr("X variable")
+							info: qsTr("Coloring by X variable")
 							enabled: (variableXPlotBuilder.count > 0 && variableColorPlotBuilder.count === 0) || (xVarRM.count > 0 && groupVarRM.count === 0)
 							checked: false
-							onEnabledChanged: { if (!enabled && checked) { checked = false; } }
+							onEnabledChanged: { if (!enabled && checked) checked = false }
 						}
 						RadioButton {
 							id: colorYRadio
 							value: "y"
 							label: qsTr("Y variable")
+							info: qsTr("Coloring by Y variable")
 							enabled: (variableYPlotBuilder.count > 0 && variableColorPlotBuilder.count === 0) || (groupVarRM.count === 0)
 							checked: false
-							onEnabledChanged: { if (!enabled && checked) { checked = false; } }
+							onEnabledChanged: { if (!enabled && checked) checked = false }
 						}
-
 						RadioButton {
 							value: "splitColumn"
+							info: qsTr("Apply separate colours in different splits")
 							label: qsTr("Split (column)")
 							enabled: columnsvariableSplitPlotBuilder.count > 0 || colSplitRM.count > 0
 							checked: false
-							onEnabledChanged: { if (!enabled && checked) { checked = false; } }
+							onEnabledChanged: { if (!enabled && checked) checked = false }
 						}
-
 						RadioButton {
 							value: "splitRow"
 							label: qsTr("Split (rows)")
+							info: qsTr("Apply separate colours in different splits")
 							enabled: rowsvariableSplitPlotBuilder.count > 0 || rowSplitRM.count > 0
 							checked: false
-							onEnabledChanged: { if (!enabled && checked) { checked = false; } }
+							onEnabledChanged: { if (!enabled && checked) checked = false }
 						}
 					}
-
 
 					DropDown {
 						name: "colorsAll"
@@ -3137,32 +2744,40 @@ Form {
 					TextField {
 						name: "customColors"
 						label: qsTr("Custom colors")
-						placeholderText: qsTr("e.g. red, blue, ##ff5733")
+						info: qsTr("Here you can specify custom colors separated by commas")
+						placeholderText: qsTr("e.g. red, blue, #ff5733")
 						fieldWidth: 150
 					}
+
 					Label {
-						text: qsTr("Note: For available colors, see %1 this page %2")
-						.arg("<a href='https://r-charts.com/colors/' style='color: blue; text-decoration: underline;'>")
-						.arg("</a>.")
+						text: qsTr("Note: For available colors, see %1this page%2")
+								.arg("<a href='https://r-charts.com/colors/' style='color: blue; text-decoration: underline;'>")
+								.arg("</a>")
 						wrapMode: Text.Wrap
 						textFormat: Text.RichText
 						MouseArea {
 							anchors.fill: parent
-							onClicked: {
-								Qt.openUrlExternally("https://r-charts.com/colors/")
-							}
+							onClicked: { Qt.openUrlExternally("https://r-charts.com/colors/") }
 						}
 					}
 				}
-
 			}
 
+
 			Section {
-				title: qsTr("Size and margins")
+				title: qsTr("Size, margins and plot orientation")
 				columns: 1
+
+				/* section-level help */
+				info: qsTr("Control the canvas dimensions and whitespace. "
+						 + "<b>Plot size</b> sets the pixel width × height, "
+						 + "<b>Axis padding</b> adds proportional space inside the axes, "
+						 + "<b>Margins</b> add outer whitespace, and "
+						 + "<b>Plot orientation</b> can flip X and Y")
 
 				Group {
 					title: qsTr("Plot size")
+					info: qsTr("Width and height of the exported figure in pixels")
 					columns: 2
 
 					DoubleField {
@@ -3183,31 +2798,34 @@ Form {
 				}
 
 				Group {
-					title: qsTr("Margins")
+					title: qsTr("Axis padding")
+					info: qsTr("Fraction of the data range to leave empty inside each axis (0 – 1)")
 					columns: 4
 
-					DoubleField {
-						name: "topMargin"
-						label: qsTr("Top")
-						value: 10
-					}
-					DoubleField {
-						name: "bottomMargin"
-						label: qsTr("Bottom")
-						value: 10
-					}
-					DoubleField {
-						name: "leftMargin"
-						label: qsTr("Left")
-						value: 10
-					}
-					DoubleField {
-						name: "rightMargin"
-						label: qsTr("Right")
-						value: 10
-					}
+					DoubleField { name: "YPaddingSecond"; label: qsTr("Top");    value: 0.05 }
+					DoubleField { name: "YPaddingFirst";  label: qsTr("Bottom"); value: 0.04 }
+					DoubleField { name: "XPaddingFirst";  label: qsTr("Left");   value: 0.05 }
+					DoubleField { name: "XPaddingSecond"; label: qsTr("Right");  value: 0.05 }
+				}
+
+				Group {
+					title: qsTr("Margins")
+					info: qsTr("Outer whitespace around the plot (pts)")
+					columns: 4
+
+					DoubleField { name: "topMargin";    label: qsTr("Top");    value: 10 }
+					DoubleField { name: "bottomMargin"; label: qsTr("Bottom"); value: 10 }
+					DoubleField { name: "leftMargin";   label: qsTr("Left");   value: 10 }
+					DoubleField { name: "rightMargin";  label: qsTr("Right");  value: 10 }
+				}
+
+				Group {
+					title: qsTr("Plot orientation")
+					info: qsTr("Flip swaps the X and Y axes")
+					CheckBox { name: "flipPlot"; label: qsTr("Flip plot") }
 				}
 			}
+
 
 			// -------------------------------------------------------------------
 			// Edit style and colors
@@ -3215,8 +2833,12 @@ Form {
 			Section {
 				title: qsTr("Legend")
 
+				info: qsTr("Control where the legend appears and what it shows. "
+						 + "Use <b>Position</b> to dock the legend or hide it. "
+						 + "<b>Remove title</b> hides the legend heading")
+
 				Group {
-					columns:2
+					columns: 2
 
 					DropDown {
 						name: "legendPosistionPlotBuilder"
@@ -3225,11 +2847,11 @@ Form {
 						indexDefaultValue: 0
 						fieldWidth: 150
 						values: [
-							{label: qsTr("Right"), value: "right"},
-							{label: qsTr("Left"), value: "left"},
-							{label: qsTr("Bottom"), value: "bottom"},
-							{label: qsTr("Top"), value: "top"},
-							{label: qsTr("No legend"), value: "none"}
+							{ label: qsTr("Right"),      value: "right" },
+							{ label: qsTr("Left"),       value: "left" },
+							{ label: qsTr("Bottom"),     value: "bottom" },
+							{ label: qsTr("Top"),        value: "top" },
+							{ label: qsTr("No legend"),  value: "none" }
 						]
 					}
 
@@ -3238,11 +2860,14 @@ Form {
 						label: qsTr("Remove title")
 					}
 				}
+
 				ComponentsList {
 					name: "colorLabelRenamer"
 					title: qsTr("Rename labels")
+					info: qsTr("Edit the text of individual legend entries")
 					addItemManually: true
 					minimumItems: 0
+
 					rowComponent: Row {
 						TextField {
 							name: "originalColorLabel"
@@ -3258,6 +2883,75 @@ Form {
 				}
 			}
 
+			Section{
+				title: qsTr("Order of geometries")
+
+				/* key ↔︎ readable name list (one per line) */
+				info: qsTr(
+					"point: Point<br>"
+				  + "histogram: Histogram<br>"
+				  + "boxplot: Boxplot<br>"
+				  + "violin: Violin plot<br>"
+				  + "count_bar: Count bar<br>"
+				  + "count_dash: Count dash<br>"
+				  + "count_line: Count line<br>"
+				  + "count_area: Count area<br>"
+				  + "count_dot: Count dot<br>"
+				  + "count_value: Count value<br>"
+				  + "sum_bar: Sum bar<br>"
+				  + "sum_dash: Sum dash<br>"
+				  + "sum_line: Sum line<br>"
+				  + "sum_area: Sum area<br>"
+				  + "sum_dot: Sum dot<br>"
+				  + "sum_value: Sum value<br>"
+				  + "barstack: Bar stack<br>"
+				  + "areastack: Area stack<br>"
+				  + "mean_bar: Mean bar<br>"
+				  + "mean_dash: Mean dash<br>"
+				  + "mean_line: Mean line<br>"
+				  + "mean_area: Mean area<br>"
+				  + "mean_dot: Mean dot<br>"
+				  + "mean_value: Mean value<br>"
+				  + "median_bar: Median bar<br>"
+				  + "median_dash: Median dash<br>"
+				  + "median_line: Median line<br>"
+				  + "median_area: Median area<br>"
+				  + "median_dot: Median dot<br>"
+				  + "median_value: Median value<br>"
+				  + "range_errorbar: Range error bar<br>"
+				  + "sd_errorbar: SD error bar<br>"
+				  + "sem_errorbar: SEM error bar<br>"
+				  + "ci95_errorbar: 95% CI error bar<br>"
+				  + "range_ribbon: Range ribbon<br>"
+				  + "sd_ribbon: SD ribbon<br>"
+				  + "sem_ribbon: SEM ribbon<br>"
+				  + "ci95_ribbon: 95% CI ribbon<br>"
+				  + "curve_fit: Curve fit<br>"
+				  + "stat_ellipse: Stat ellipse<br>"
+				  + "rm_lines: RM lines<br>"
+				  + "reference_lines: Reference lines<br>"
+				  + "identity_line: Identity line<br>"
+				  + "point_labels: Point labels"
+				)
+
+				Label {
+					text: qsTr(
+						"You can set the order of the added geometric/data layers here, similar to the example shown in the text field.\n"
+					  + "The order of the layers is defined from left to right—meaning the rightmost layer will be drawn on top."
+					)
+					wrapMode: Text.Wrap
+					color: "black"
+				}
+
+				TextField {
+					label: qsTr("Layer order")
+					name: "layerOrder"
+					placeholderText: qsTr("point, boxplot")
+					fieldWidth: 300
+				}
+			}
+
+
 			Label {
 				text: qsTr("Split and grid control")
 				wrapMode: Text.Wrap
@@ -3268,17 +2962,20 @@ Form {
 			Section {
 				title: qsTr("Split control")
 
+				/* section-level help */
+				info: qsTr("Adjust how faceted panels share scales, axes and space. "
+						 + "<b>Scale and axis settings</b> decide whether panels use the same range, which axis lines are drawn and where labels appear. "
+						 + "<b>Layout settings</b> control panel sizes, the position of the highest-value table, optional marginal plots and custom axis titles")
+
 				GridLayout {
 					columns: 2
 					rowSpacing: 10
 					columnSpacing: 20
-					enabled: columnsvariableSplitPlotBuilder.count > 0 || colSplitRM.count > 0 ||
-							 rowsvariableSplitPlotBuilder.count > 0 || rowSplitRM.count > 0
+					enabled: columnsvariableSplitPlotBuilder.count > 0 || colSplitRM.count > 0
+						  || rowsvariableSplitPlotBuilder.count > 0    || rowSplitRM.count > 0
 
-
-					Label {
-						text: qsTr("Scale and axis settings")
-					}
+					/* ────────── Scale and axis settings ────────── */
+					Label { text: qsTr("Scale and axis settings") }
 
 					Column {
 						spacing: 10
@@ -3286,11 +2983,12 @@ Form {
 						DropDown {
 							name: "scales"
 							label: qsTr("Scale range")
+							info: qsTr("Choose whether facet panels share a common scale (<i>fixed</i>) or get individual ranges")
 							values: [
 								{ label: qsTr("shared across all facets"), value: "fixed" },
-								{ label: qsTr("vary across X"), value: "free_x" },
-								{ label: qsTr("vary across Y"), value: "free_y" },
-								{ label: qsTr("vary across both axes"), value: "free" }
+								{ label: qsTr("vary across X"),            value: "free_x" },
+								{ label: qsTr("vary across Y"),            value: "free_y" },
+								{ label: qsTr("vary across both axes"),    value: "free" }
 							]
 							startValue: "fixed"
 						}
@@ -3298,11 +2996,12 @@ Form {
 						DropDown {
 							name: "axes"
 							label: qsTr("Show axis lines")
+							info: qsTr("Decide which facet panels display axis lines")
 							values: [
 								{ label: qsTr("only on outer panels"), value: "margins" },
-								{ label: qsTr("on all X axes"), value: "all_x" },
-								{ label: qsTr("on all Y axes"), value: "all_y" },
-								{ label: qsTr("on all axes"), value: "all" }
+								{ label: qsTr("on all X axes"),        value: "all_x" },
+								{ label: qsTr("on all Y axes"),        value: "all_y" },
+								{ label: qsTr("on all axes"),          value: "all" }
 							]
 							startValue: "margins"
 						}
@@ -3310,9 +3009,10 @@ Form {
 						DropDown {
 							name: "axisLabels"
 							label: qsTr("Axis label visibility")
+							info: qsTr("Control which tick-label texts are shown")
 							values: [
-								{ label: qsTr("show on all axes"), value: "all" },
-								{ label: qsTr("only on outer axes"), value: "margins" },
+								{ label: qsTr("show on all axes"),        value: "all" },
+								{ label: qsTr("only on outer axes"),      value: "margins" },
 								{ label: qsTr("only on interior X axes"), value: "all_x" },
 								{ label: qsTr("only on interior Y axes"), value: "all_y" }
 							]
@@ -3320,9 +3020,8 @@ Form {
 						}
 					}
 
-					Label {
-						text: qsTr("Layout settings")
-					}
+					/* ────────── Layout settings ────────── */
+					Label { text: qsTr("Layout settings") }
 
 					Column {
 						spacing: 10
@@ -3331,6 +3030,7 @@ Form {
 							id: asTableGroup
 							name: "asTable"
 							title: qsTr("Highest value at")
+							info: qsTr("Controls where the summary table of highest values is placed inside each facet")
 							radioButtonsOnSameRow: true
 
 							RadioButton {
@@ -3347,11 +3047,12 @@ Form {
 						DropDown {
 							name: "space"
 							label: qsTr("Panel size adjustment")
+							info: qsTr("Allow facet panels to stretch freely along X, Y or both axes")
 							values: [
-								{ label: qsTr("same size"), value: "fixed" },
-								{ label: qsTr("free width (X)"), value: "free_x" },
-								{ label: qsTr("free height (Y)"), value: "free_y" },
-								{ label: qsTr("free width and height"), value: "free" }
+								{ label: qsTr("same size"),               value: "fixed" },
+								{ label: qsTr("free width (X)"),          value: "free_x" },
+								{ label: qsTr("free height (Y)"),         value: "free_y" },
+								{ label: qsTr("free width and height"),   value: "free" }
 							]
 							startValue: "fixed"
 						}
@@ -3360,16 +3061,16 @@ Form {
 							id: marginsCheckBox
 							name: "margins"
 							label: qsTr("Include marginal plots")
+							info: qsTr("Adds aggregated rows/columns at the edges of the facet grid")
 							checked: false
 						}
 
-						// New text fields for X/Y axis titles:
+						/* custom axis titles for split layouts */
 						TextField {
 							name: "xAxisTitleSplit"
 							label: qsTr("X axis title")
 							placeholderText: qsTr("Enter a label for the X axis")
 						}
-
 						TextField {
 							name: "yAxisTitleSplit"
 							label: qsTr("Y axis title")
@@ -3379,19 +3080,22 @@ Form {
 				}
 			}
 
+
 			Section {
 				title: qsTr("Grid control")
+
+				/* section-level help */
+				info: qsTr("Arrange panels when a grid variable is mapped. "
+						 + "<b>Layout settings</b> set the facet grid’s rows, columns and where the highest-values table appears, "
+						 + "<b>Scales and strip settings</b> decide whether panels share axes and where the facet label strip is placed")
+
 				GridLayout {
-
 					enabled: gridVariablePlotBuilder.count > 0 || gridVarRM.count > 0
-
 					columns: 2
 					rowSpacing: 10
 					columnSpacing: 20
 
-					Label {
-						text: qsTr("Layout settings")
-					}
+					Label { text: qsTr("Layout settings") }
 
 					Column {
 						spacing: 10
@@ -3399,24 +3103,26 @@ Form {
 						DoubleField {
 							name: "ncolFacetWrap"
 							label: qsTr("Number of columns")
+							info: qsTr("Fixed number of facet columns; 0 lets the layout pick automatically")
 							defaultValue: gridVariablePlotBuilder.levels ? Math.floor(gridVariablePlotBuilder.levels / 2) + 1 : 0
 						}
 
 						DoubleField {
 							name: "nrowFacetWrap"
 							label: qsTr("Number of rows")
+							info: qsTr("Fixed number of facet rows; 0 lets the layout pick automatically")
 							defaultValue: gridVariablePlotBuilder.levels ? Math.floor(gridVariablePlotBuilder.levels / 2) + 1 : 0
 						}
-
 
 						RadioButtonGroup {
 							name: "asTableFacetWrap"
 							title: qsTr("Highest value at")
+							info: qsTr("Choose the corner where the summary table of highest values is drawn")
 							radioButtonsOnSameRow: true
 
 							RadioButton {
 								value: "bottom-rightFacetWrap"
-								label: qsTr("bottomright")
+								label: qsTr("bottom right")
 								checked: true
 							}
 							RadioButton {
@@ -3426,9 +3132,7 @@ Form {
 						}
 					}
 
-					Label {
-						text: qsTr("Scales and strip settings")
-					}
+					Label { text: qsTr("Scales and strip settings") }
 
 					Column {
 						spacing: 10
@@ -3436,11 +3140,12 @@ Form {
 						DropDown {
 							name: "scalesFacetWrap"
 							label: qsTr("Scale range")
+							info: qsTr("Fixed panels share axes; free panels get independent X and/or Y scales")
 							values: [
 								{ label: qsTr("shared across all facets"), value: "fixed" },
-								{ label: qsTr("vary across X"), value: "free_x" },
-								{ label: qsTr("vary across Y"), value: "free_y" },
-								{ label: qsTr("vary across both axes"), value: "free" }
+								{ label: qsTr("vary across X"),            value: "free_x" },
+								{ label: qsTr("vary across Y"),            value: "free_y" },
+								{ label: qsTr("vary across both axes"),    value: "free" }
 							]
 							startValue: "fixed"
 						}
@@ -3448,17 +3153,19 @@ Form {
 						DropDown {
 							name: "stripPosition"
 							label: qsTr("Strip position")
+							info: qsTr("Location of the facet label strip")
 							values: [
-								{ label: qsTr("top"), value: "top" },
+								{ label: qsTr("top"),    value: "top" },
 								{ label: qsTr("bottom"), value: "bottom" },
-								{ label: qsTr("left"), value: "left" },
-								{ label: qsTr("right"), value: "right" }
+								{ label: qsTr("left"),   value: "left" },
+								{ label: qsTr("right"),  value: "right" }
 							]
 							startValue: "top"
 						}
 					}
 				}
 			}
+
 
 			Label {
 				text: qsTr("P value and comparison lines")
@@ -3470,7 +3177,11 @@ Form {
 			Section {
 
 				title: qsTr("P value brackets")
-				columns: 4
+				columns: 3
+
+				/* section-level help */
+				info: qsTr("Add brackets with P values to show pairwise significance.\n"
+						 + "Set colour, text size and vertical spacing, then list each comparison in the table below")
 
 				Label {
 					text: qsTr("Required: X AND Y-Axis Variables")
@@ -3478,15 +3189,18 @@ Form {
 					color: "black"
 				}
 
-
-				Group{
+				Group {
 					columns: 2
 
-					Group{
+					/* ── Text appearance ── */
+					Group {
 						columns: 1
+						info: qsTr("Colour and font size of the P-value text")
+
 						TextField {
 							name: "labelcolor"
 							label: qsTr("P value color")
+							info: qsTr("Named or hex colour for the P value text")
 							fieldWidth: 70
 							defaultValue: "black"
 						}
@@ -3494,15 +3208,20 @@ Form {
 						DoubleField {
 							name: "labelSizePValue"
 							label: qsTr("P value size")
+							info: qsTr("Font size of the P value text")
 							defaultValue: 4.5
 						}
 					}
 
-					Group{
-						columns:1
+					/* ── Vertical placement ── */
+					Group {
+						columns: 1
+						info: qsTr("Starting height and step between stacked brackets (data units)")
+
 						DoubleField {
 							name: "yPositionPValue"
 							label: qsTr("Y-Axis position of the first P value")
+							info: qsTr("Initial vertical position for the first bracket")
 							decimals: 2
 							fieldWidth: 70
 							value: 70
@@ -3511,13 +3230,15 @@ Form {
 						DoubleField {
 							name: "stepDistance"
 							label: qsTr("Step distance")
+							info: qsTr("Vertical gap between successive brackets")
 							decimals: 2
 							fieldWidth: 70
 							value: 0.15
 						}
 
 						Label {
-							text: qsTr("Note: If custom Y-Axis limits are set, the starting" + "\n" + "position for the P value must fall within the defined interval")
+							text: qsTr("Note: If custom Y-Axis limits are set, the starting\n"
+									   + "position for the P value must fall within the defined interval")
 							wrapMode: Text.Wrap
 							color: "black"
 						}
@@ -3533,26 +3254,14 @@ Form {
 					maximumItems: -1
 
 					enabled: (
-								 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
 								 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-
-								 ||
-
-								 // 2. If repeated measures (yesRM) and at least one of the following is true:
-								 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-									  xVarRM.count > 0
-
-									  ))
-								 )
-
+							  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+							 )
 
 					onEnabledChanged: {
 						if (!enabled) {
-							// remove all components one by one
-							for (var i = pairwiseComparisons.count - 1; i >= 0; --i) {
+							for (var i = pairwiseComparisons.count - 1; i >= 0; --i)
 								pairwiseComparisons.removeItem(i)
-							}
 						}
 					}
 
@@ -3562,8 +3271,10 @@ Form {
 							title: qsTr("Bracket ") + (rowIndex + 1)
 							columns: 3
 
+							/* Compared groups ------------------------------------ */
 							Group {
 								title: qsTr("Compared groups")
+								info: qsTr("Labels of the two groups being compared")
 
 								TextField {
 									name: "group1"
@@ -3578,26 +3289,19 @@ Form {
 								}
 							}
 
-							Group{
+							/* P value & bracket style ---------------------------- */
+							Group {
 								title: qsTr("P value and brackets")
-
-
-								// DoubleField {
-								//     name: "pAdj"
-								//     label: qsTr("P value")
-								//     decimals: 2
-								//     fieldWidth: 70
-								//     value: 0.03
-								// }
+								info: qsTr("Enter the P value (e.g. 0.03) or a significance symbol (*, **, ***). "
+										 + "<b>Tip length</b> is the size of the bracket tips; "
+										 + "<b>Bracket size</b> is the horizontal width")
 
 								TextField {
 									name: "pAdj"
-									label: qsTr("Group 2")
+									label: qsTr("P value")
 									fieldWidth: 60
 									value: "* or 0.001"
 								}
-
-
 
 								DoubleField {
 									name: "tipLengthPValue"
@@ -3616,148 +3320,67 @@ Form {
 								}
 							}
 
+							/* Facet position ------------------------------------- */
 							Group {
 								title: qsTr("Position")
 								columns: 2
+								info: qsTr("Select the facet (group/column/row/grid) where the bracket should appear")
 
+								/* group selectors */
+								DropDown { name: "GroupPValue";  label: qsTr("Group");  values: variableColorPlotBuilder.levels; visible: noRM.checked; enabled: noRM.checked; onEnabledChanged: { if (!enabled) currentIndex = -1 } }
+								DropDown { name: "RMGroupPValue"; label: qsTr("Group"); visible: yesRM.checked; enabled: yesRM.checked;
+										   values: groupVarRM.columnsNames.length > 0
+												   ? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(groupVarRM.columnsNames[0])
+													  ? repeatedMeasuresFactors.factorLevelMap[groupVarRM.columnsNames[0]]
+													  : groupVarRM.levels)
+												   : [];
+										   addEmptyValue: groupValue.columnsNames.length === 0; placeholderText: qsTr("<No Value>");
+										   onEnabledChanged: { if (!enabled) currentIndex = -1 } }
 
-								DropDown {
-									name: "GroupPValue"
-									label: qsTr("Group")
-									values: variableColorPlotBuilder.levels
-									visible: noRM.checked
-									enabled: noRM.checked
-									onEnabledChanged: {
-										if (!enabled) {
-											currentIndex = -1
-										}
-									}
-								}
+								/* column selectors */
+								DropDown { name: "ColumnPValue";  label: qsTr("Column"); values: columnsvariableSplitPlotBuilder.levels; visible: noRM.checked; enabled: noRM.checked; onEnabledChanged: { if (!enabled) currentIndex = -1 } }
+								DropDown { name: "RMColumnPValue"; label: qsTr("Column"); visible: yesRM.checked; enabled: yesRM.checked;
+										   values: colSplitRM.columnsNames.length > 0
+												   ? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(colSplitRM.columnsNames[0])
+													  ? repeatedMeasuresFactors.factorLevelMap[colSplitRM.columnsNames[0]]
+													  : colSplitRM.levels)
+												   : [];
+										   addEmptyValue: groupValue.columnsNames.length === 0; placeholderText: qsTr("<No Value>");
+										   onEnabledChanged: { if (!enabled) currentIndex = -1 } }
 
-								DropDown {
-									name: "RMGroupPValue";
-									label: qsTr("Group");
-									visible: yesRM.checked
-									enabled: yesRM.checked
-									values: groupVarRM.columnsNames.length > 0
-											? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(groupVarRM.columnsNames[0])
-											   ? repeatedMeasuresFactors.factorLevelMap[groupVarRM.columnsNames[0]]
-											   : groupVarRM.levels)
-											: []
-									addEmptyValue: groupValue.columnsNames.length === 0
-									placeholderText: qsTr("<No Value>")
-									onEnabledChanged: {
-										if (!enabled) {
-											currentIndex = -1
-										}
-									}
-								}
+								/* row selectors */
+								DropDown { name: "RowPValue";  label: qsTr("Row"); values: rowsvariableSplitPlotBuilder.levels; visible: noRM.checked; enabled: noRM.checked; onEnabledChanged: { if (!enabled) currentIndex = -1 } }
+								DropDown { name: "RMRowPValue"; label: qsTr("Row"); visible: yesRM.checked; enabled: yesRM.checked;
+										   values: rowSplitRM.columnsNames.length > 0
+												   ? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(rowSplitRM.columnsNames[0])
+													  ? repeatedMeasuresFactors.factorLevelMap[rowSplitRM.columnsNames[0]]
+													  : rowSplitRM.levels)
+												   : [];
+										   addEmptyValue: groupValue.columnsNames.length === 0; placeholderText: qsTr("<No Value>");
+										   onEnabledChanged: { if (!enabled) currentIndex = -1 } }
 
-								DropDown {
-									name: "ColumnPValue"
-									label: qsTr("Column")
-									values: columnsvariableSplitPlotBuilder.levels
-									visible: noRM.checked
-									enabled: noRM.checked
-									onEnabledChanged: {
-										if (!enabled) {
-											currentIndex = -1
-										}
-									}
-								}
-
-								DropDown {
-									name: "RMColumnPValue";
-									label: qsTr("Column");
-									visible: yesRM.checked
-									enabled: yesRM.checked
-									values: colSplitRM.columnsNames.length > 0
-											? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(colSplitRM.columnsNames[0])
-											   ? repeatedMeasuresFactors.factorLevelMap[colSplitRM.columnsNames[0]]
-											   : colSplitRM.levels)
-											: []
-									addEmptyValue: groupValue.columnsNames.length === 0
-									placeholderText: qsTr("<No Value>")
-									onEnabledChanged: {
-										if (!enabled) {
-											currentIndex = -1
-										}
-									}
-								}
-
-								DropDown {
-									name: "RowPValue"
-									label: qsTr("Row")
-									values: rowsvariableSplitPlotBuilder.levels
-									visible: noRM.checked
-									enabled: noRM.checked
-									onEnabledChanged: {
-										if (!enabled) {
-											currentIndex = -1
-										}
-									}
-								}
-
-								DropDown {
-									name: "RMRowPValue";
-									label: qsTr("Row");
-									visible: yesRM.checked
-									enabled: yesRM.checked
-									values: rowSplitRM.columnsNames.length > 0
-											? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(rowSplitRM.columnsNames[0])
-											   ? repeatedMeasuresFactors.factorLevelMap[rowSplitRM.columnsNames[0]]
-											   : rowSplitRM.levels)
-											: []
-									addEmptyValue: groupValue.columnsNames.length === 0
-									placeholderText: qsTr("<No Value>")
-									onEnabledChanged: {
-										if (!enabled) {
-											currentIndex = -1
-										}
-									}
-								}
-
-								DropDown {
-									name: "GridPValue"
-									label: qsTr("Grid")
-									values: gridVariablePlotBuilder.levels
-									visible: noRM.checked
-									enabled: noRM.checked
-									onEnabledChanged: {
-										if (!enabled) {
-											currentIndex = -1
-										}
-									}
-								}
-
-								DropDown {
-									name: "RMGridPValue";
-									label: qsTr("Grid");
-									visible: yesRM.checked
-									enabled: yesRM.checked
-									values: gridVarRM.columnsNames.length > 0
-											? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(gridVarRM.columnsNames[0])
-											   ? repeatedMeasuresFactors.factorLevelMap[gridVarRM.columnsNames[0]]
-											   : gridVarRM.levels)
-											: []
-									addEmptyValue: groupValue.columnsNames.length === 0
-									placeholderText: qsTr("<No Value>")
-									onEnabledChanged: {
-										if (!enabled) {
-											currentIndex = -1
-										}
-									}
-								}
+								/* grid selectors */
+								DropDown { name: "GridPValue";  label: qsTr("Grid"); values: gridVariablePlotBuilder.levels; visible: noRM.checked; enabled: noRM.checked; onEnabledChanged: { if (!enabled) currentIndex = -1 } }
+								DropDown { name: "RMGridPValue"; label: qsTr("Grid"); visible: yesRM.checked; enabled: yesRM.checked;
+										   values: gridVarRM.columnsNames.length > 0
+												   ? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(gridVarRM.columnsNames[0])
+													  ? repeatedMeasuresFactors.factorLevelMap[gridVarRM.columnsNames[0]]
+													  : gridVarRM.levels)
+												   : [];
+										   addEmptyValue: groupValue.columnsNames.length === 0; placeholderText: qsTr("<No Value>");
+										   onEnabledChanged: { if (!enabled) currentIndex = -1 } }
 							}
-
 						}
-
 					}
 				}
 			}
 
-			Section{
+
+			Section {
 				title: qsTr("Custom comparison lines")
+				columns: 4
+				/* section-level help */
+				info: qsTr("Draw manual comparison lines (e.g., **min–max bars** or custom contrasts) with optional text labels")
 
 				Label {
 					text: qsTr("Required: X AND Y-Axis Variables")
@@ -3766,191 +3389,116 @@ Form {
 				}
 
 				Label {
-					text: qsTr("Note: If custom Y-Axis limits are set, the starting" + "\n" + "position for the Y-Axis starnd and end values must fall within the defined interval")
+					text: qsTr("Note: If custom Y-Axis limits are set, the starting\n"
+							   + "position for the Y-Axis start and end values must fall within the defined interval")
 					wrapMode: Text.Wrap
 					color: "black"
 				}
 
 				ComponentsList {
 					name: "annotationLineList"
-					id:annotationLineList
+					id: annotationLineList
 					title: qsTr("Add annotation lines")
 					addItemManually: true
 					minimumItems: 0
+
 					enabled: (
-								 // 1. If not repeated measures (noRM) and both X and Y variables are assigned
 								 (noRM.checked && variableXPlotBuilder.count > 0 && variableYPlotBuilder.count > 0)
-
-								 ||
-
-								 // 2. If repeated measures (yesRM) and at least one of the following is true:
-								 (yesRM.checked && repeatedMeasuresFactors.count > 0 && (
-
-									  xVarRM.count > 0
-
-									  ))
-								 )
+							  || (yesRM.checked && repeatedMeasuresFactors.count > 0 && xVarRM.count > 0)
+							 )
 
 					onEnabledChanged: {
 						if (!enabled) {
-							// remove all components one by one
-							for (var i = annotationLineList.count - 1; i >= 0; --i) {
+							for (var i = annotationLineList.count - 1; i >= 0; --i)
 								annotationLineList.removeItem(i)
-							}
 						}
 					}
 
 					rowComponent: Row {
 
-
 						Group {
-							columns: 5
+							columns: 4
 							title: qsTr("Line ") + (rowIndex + 1)
+							info: qsTr("Define one comparison line with optional label, coordinates and appearance")
 
-							Group{
+							/* ── Label text ── */
+							Group {
 								title: qsTr("Label")
 								TextField {
 									name: "textAnnotationline"
 									label: qsTr("Label")
+									info: qsTr("Text shown near the line (leave empty for no label)")
 									fieldWidth: 60
 								}
 							}
 
-
+							/* ── Position ── */
 							Group {
 								title: qsTr("Position")
 								columns: 4
+								info: qsTr("Start/end coordinates and facet location")
 
 								Group {
-									DoubleField {
-										name: "xAnnotation"
-										label: qsTr("X-Axis start")
-									}
-									DoubleField {
-										name: "xendAnnotation"
-										label: qsTr("X-Axis end")
-									}
+									DoubleField { name: "xAnnotation";  label: qsTr("X-Axis start"); info: qsTr("Line start on X axis") }
+									DoubleField { name: "xendAnnotation"; label: qsTr("X-Axis end");  info: qsTr("Line end on X axis") }
 								}
-
 								Group {
-									DoubleField {
-										name: "yAnnotation"
-										label: qsTr("Y-Axis start")
-									}
-									DoubleField {
-										name: "yendAnnotation"
-										label: qsTr("Y-Axis end")
-									}
+									DoubleField { name: "yAnnotation";  label: qsTr("Y-Axis start"); info: qsTr("Line start on Y axis") }
+									DoubleField { name: "yendAnnotation"; label: qsTr("Y-Axis end"); info: qsTr("Line end on Y axis") }
 								}
 
-								Group{
+								Group {columns: 1
 
-									DropDown {
-										name: "ColumnAnnotationCompLine"
-										label: qsTr("Column")
-										values: columnsvariableSplitPlotBuilder.levels
-										visible: noRM.checked
-										enabled: noRM.checked
-										onEnabledChanged: {
-											if (!enabled) {
-												currentIndex = -1
-											}
-										}
-									}
+									DropDown { name: "ColumnAnnotationCompLine"; label: qsTr("Column"); values: columnsvariableSplitPlotBuilder.levels;
+											   visible: noRM.checked; enabled: noRM.checked;
+											   info: qsTr("Facet column (for split layouts)"); onEnabledChanged: { if (!enabled) currentIndex = -1 } }
+									DropDown { name: "RowAnnotationCompLine";    label: qsTr("Row");    values: rowsvariableSplitPlotBuilder.levels;
+											   visible: noRM.checked; enabled: noRM.checked;
+											   info: qsTr("Facet row (for split layouts)");    onEnabledChanged: { if (!enabled) currentIndex = -1 } }
+									DropDown { name: "GridAnnotationCompLine";   label: qsTr("Grid");   values: gridVariablePlotBuilder.levels;
+											   visible: noRM.checked; enabled: noRM.checked;
+											   info: qsTr("Facet grid cell");                   onEnabledChanged: { if (!enabled) currentIndex = -1 } }
 
-									DropDown{
-										name: "RMColumnCompLine";
-										label: qsTr("Column");
-										visible: yesRM.checked
-										enabled: yesRM.checked
-										values: colSplitRM.columnsNames.length > 0
-												? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(colSplitRM.columnsNames[0])
-												   ? repeatedMeasuresFactors.factorLevelMap[colSplitRM.columnsNames[0]]
-												   : colSplitRM.levels)
-												: []
-										addEmptyValue: groupValue.columnsNames.length === 0
-										placeholderText: qsTr("<No Value>")
-										onEnabledChanged: {
-											if (!enabled) {
-												currentIndex = -1
-											}
-										}
-									}
+									/* facet selectors – RM */
+									DropDown { name: "RMColumnCompLine"; label: qsTr("Column"); visible: yesRM.checked; enabled: yesRM.checked;
+											   info: qsTr("Facet column (RM)"); values: colSplitRM.columnsNames.length > 0
+														  ? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(colSplitRM.columnsNames[0])
+															 ? repeatedMeasuresFactors.factorLevelMap[colSplitRM.columnsNames[0]]
+															 : colSplitRM.levels)
+														  : [];
+											   addEmptyValue: groupValue.columnsNames.length === 0; placeholderText: qsTr("<No Value>");
+											   onEnabledChanged: { if (!enabled) currentIndex = -1 } }
 
-									DropDown {
-										name: "RowAnnotationCompLine"
-										label: qsTr("Row")
-										values: rowsvariableSplitPlotBuilder.levels
-										visible: noRM.checked
-										enabled: noRM.checked
-										onEnabledChanged: {
-											if (!enabled) {
-												currentIndex = -1
-											}
-										}
-									}
+									DropDown { name: "RMRowCompLine"; label: qsTr("Row"); visible: yesRM.checked; enabled: yesRM.checked;
+											   info: qsTr("Facet row (RM)"); values: rowSplitRM.columnsNames.length > 0
+														  ? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(rowSplitRM.columnsNames[0])
+															 ? repeatedMeasuresFactors.factorLevelMap[rowSplitRM.columnsNames[0]]
+															 : rowSplitRM.levels)
+														  : [];
+											   addEmptyValue: groupValue.columnsNames.length === 0; placeholderText: qsTr("<No Value>");
+											   onEnabledChanged: { if (!enabled) currentIndex = -1 } }
 
-									DropDown{
-										name: "RMRowCompLine";
-										label: qsTr("Row");
-										visible: yesRM.checked
-										enabled: yesRM.checked
-										values: rowSplitRM.columnsNames.length > 0
-												? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(rowSplitRM.columnsNames[0])
-												   ? repeatedMeasuresFactors.factorLevelMap[rowSplitRM.columnsNames[0]]
-												   : rowSplitRM.levels)
-												: []
-										addEmptyValue: groupValue.columnsNames.length === 0
-										placeholderText: qsTr("<No Value>")
-										onEnabledChanged: {
-											if (!enabled) {
-												currentIndex = -1
-											}
-										}
-									}
-
-									DropDown {
-										name: "GridAnnotationCompLine"
-										label: qsTr("Grid")
-										values: gridVariablePlotBuilder.levels
-										visible: noRM.checked
-										enabled: noRM.checked
-										onEnabledChanged: {
-											if (!enabled) {
-												currentIndex = -1
-											}
-										}
-									}
-
-									DropDown{
-										name: "RMGridCompLine";
-										label: qsTr("Grid");
-										visible: yesRM.checked
-										enabled: yesRM.checked
-										values: gridVarRM.columnsNames.length > 0
-												? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(gridVarRM.columnsNames[0])
-												   ? repeatedMeasuresFactors.factorLevelMap[gridVarRM.columnsNames[0]]
-												   : gridVarRM.levels)
-												: []
-										addEmptyValue: groupValue.columnsNames.length === 0
-										placeholderText: qsTr("<No Value>")
-										onEnabledChanged: {
-											if (!enabled) {
-												currentIndex = -1
-											}
-										}
-									}
-
-								}
+									DropDown { name: "RMGridCompLine"; label: qsTr("Grid"); visible: yesRM.checked; enabled: yesRM.checked;
+											   info: qsTr("Facet grid cell (RM)"); values: gridVarRM.columnsNames.length > 0
+														  ? (repeatedMeasuresFactors.factorLevelMap.hasOwnProperty(gridVarRM.columnsNames[0])
+															 ? repeatedMeasuresFactors.factorLevelMap[gridVarRM.columnsNames[0]]
+															 : gridVarRM.levels)
+														  : [];
+											   addEmptyValue: groupValue.columnsNames.length === 0; placeholderText: qsTr("<No Value>");
+											   onEnabledChanged: { if (!enabled) currentIndex = -1 } }}
+								/* facet selectors – noRM */
 
 							}
 
-							Group{
+							/* ── Appearance ── */
+							Group {
 								title: qsTr("Appearance")
+								info: qsTr("Line colour and label styling")
 
 								TextField {
 									name: "colorAnnotationLine"
 									label: qsTr("Line color")
+									info: qsTr("Named or hex colour for the line")
 									placeholderText: qsTr("e.g. black, #ff5733")
 									defaultValue: "black"
 									fieldWidth: 60
@@ -3959,6 +3507,7 @@ Form {
 								DoubleField {
 									name: "textSizeAnnotationLine"
 									label: qsTr("Label size")
+									info: qsTr("Font size of the label text")
 									defaultValue: 5.5
 									fieldWidth: 60
 								}
@@ -3966,16 +3515,14 @@ Form {
 								DoubleField {
 									name: "textDistanceAnnotationLine"
 									label: qsTr("Label distance")
+									info: qsTr("Vertical offset between the line and its label (data units)")
 									defaultValue: 0.5
 									fieldWidth: 60
 								}
 							}
-
 						}
-
 					}
 				}
-
 			}
 
 		}
@@ -3985,17 +3532,23 @@ Form {
 		title: qsTr("Plot layout")
 		columns: 1
 
+		/* section-level help */
+		info: qsTr("Combine multiple plots in custom grids. "
+				 + "<b>Arrange plots by column</b> builds the top part of the layout, "
+				 + "<b>Arrange plots by row</b> builds the bottom. "
+				 + "Specify plot IDs, relative sizes and optional common legends")
+
 		Group {
 			title: qsTr("Arrange plots by column")
 
-			// Relative width of the columns
+			/* relative width string */
 			TextField {
 				name: "columnWidthInput"
 				label: qsTr("Relative column widths")
+				info: qsTr("Comma-separated numbers that set the width of each column")
 				placeholderText: qsTr("1,1")
 			}
 
-			// Row Specifications ComponentsList
 			ComponentsList {
 				id: rowSpecifications
 				name: "rowSpecifications"
@@ -4010,13 +3563,14 @@ Form {
 						TextField {
 							name: "plotIDs"
 							label: qsTr("Plot IDs")
+							info: qsTr("Comma-separated IDs referencing earlier plots")
 							placeholderText: qsTr("Plot 1, Plot 2, ...")
 						}
 
 						TextField {
 							name: "rowHeightsColumn"
 							label: qsTr("Plot heights")
-							info: qsTr("Specify the relative heights of the plots in the specified column.")
+							info: qsTr("Relative heights of plots within this column")
 							placeholderText: qsTr("1,1")
 						}
 					}
@@ -4027,6 +3581,7 @@ Form {
 						TextField {
 							name: "labelsColumn"
 							label: qsTr("Labels")
+							info: qsTr("Optional plot labels (A, B, …)")
 							placeholderText: qsTr("A, B, C, ...")
 							fieldWidth: 150
 						}
@@ -4034,6 +3589,7 @@ Form {
 						CheckBox {
 							name: "getCommonLegendColumn"
 							label: qsTr("Collect legend")
+							info: qsTr("Merge legends of all plots in this column")
 						}
 					}
 				}
@@ -4043,14 +3599,13 @@ Form {
 		Group {
 			title: qsTr("Arrange plots by row")
 
-			// Relative height within row layout
 			TextField {
 				name: "relHeightWithinRowLayout"
 				label: qsTr("Relative row heights")
+				info: qsTr("Comma-separated numbers that set the height of each row")
 				placeholderText: "1,1"
 			}
 
-			// Full Row Specifications ComponentsList
 			ComponentsList {
 				id: fullRowSpecifications
 				name: "fullRowSpecifications"
@@ -4065,13 +3620,14 @@ Form {
 						TextField {
 							name: "plotIDsFullRow"
 							label: qsTr("Plot IDs")
+							info: qsTr("Comma-separated IDs referencing earlier plots")
 							placeholderText: qsTr("Plot 1, Plot 2, ...")
 						}
 
 						TextField {
 							name: "relWidthsFullRow"
 							label: qsTr("Plot widths")
-							info: qsTr("Specify the relative widths of the plots in the specified row.")
+							info: qsTr("Relative widths of plots within this row")
 							placeholderText: "1,1"
 						}
 					}
@@ -4082,6 +3638,7 @@ Form {
 						TextField {
 							name: "labelsFullRow"
 							label: qsTr("Labels")
+							info: qsTr("Optional plot labels (A, B, …)")
 							placeholderText: qsTr("A, B, C, ...")
 							fieldWidth: 150
 						}
@@ -4089,21 +3646,22 @@ Form {
 						CheckBox {
 							name: "getCommonLegendRows"
 							label: qsTr("Collect legend")
+							info: qsTr("Merge legends of all plots in this row")
 						}
 					}
 				}
 			}
 		}
 
-
 		Label {
-			text: qsTr("Note: If you have column and row arrangement," + "\n" + "the column will be the top part of the layout" + "\n" + "and the row will be the bottom part of the layout.")
+			text: qsTr("Note: If you have column and row arrangement,\n"
+					   + "the column will be the top part of the layout\n"
+					   + "and the row will be the bottom part of the layout.")
 			wrapMode: Text.Wrap
 			color: "black"
 		}
 
-
-
+		/* label settings -------------------------------------------------- */
 		Group {
 			columns: 3
 			title: qsTr("Label settings")
@@ -4111,27 +3669,30 @@ Form {
 			DoubleField {
 				name: "labelSize"
 				label: qsTr("Label size")
+				info: qsTr("Font size of subplot labels")
 				value: 18
 			}
 
 			DoubleField {
 				name: "labelDistance1"
 				label: qsTr("Horizontal position")
+				info: qsTr("Horizontal offset of labels (0–1, relative to plot width)")
 				value: 0.05
 				min: 0
 				max: 1
 			}
 
-
 			DoubleField {
 				name: "labelDistance2"
 				label: qsTr("Vertical position")
+				info: qsTr("Vertical offset of labels (0–1, relative to plot height)")
 				value: 0.95
 				min: 0
 				max: 1
 			}
 		}
 
+		/* additional layout sizing --------------------------------------- */
 		Group {
 			title: qsTr("Additional settings")
 
@@ -4142,37 +3703,42 @@ Form {
 					TextField {
 						name: "relativeHeight"
 						label: qsTr("Column heights/row widths")
+						info: qsTr("Relative heights of columns or widths of rows when combining column and row layouts")
 						placeholderText: "1,1"
-						info: qsTr("Specify the relative heights of the columns or widths of the rows in the plot layout.")
 						fieldWidth: 150
 					}
 
 					DoubleField {
 						name: "layoutWidth"
 						label: qsTr("Width")
+						info: qsTr("Overall width of the assembled layout (pixels)")
 						value: 500
 					}
 
 					DoubleField {
 						name: "layoutHeight"
 						label: qsTr("Height")
+						info: qsTr("Overall height of the assembled layout (pixels)")
 						value: 500
 					}
 
 					DoubleField {
 						name: "plotSpacing"
 						label: qsTr("Spacing")
+						info: qsTr("Gap between plots inside the layout (pixels)")
 						value: 10
 					}
 
 					CheckBox {
 						name: "getCommonLegend"
 						label: qsTr("Collect legend across layout")
+						info: qsTr("Place a single shared legend for all plots in the layout")
 					}
 				}
 			}
 		}
 	}
+
 }
 
 // End Form


### PR DESCRIPTION
Replaced the histogram script, now using ggplot instead of tidyplot.

Added density plot support, also implemented with ggplot instead of tidyplot.

Added stat ellipse around data points.

Enabled data point size to be mapped to another variable.

Enabled data point shape to be mapped to another variable.

Cleaned up the info code (shortened QML, removed line breaks, no content change).
Fix: https://github.com/jasp-stats/jasp-test-release/issues/2955

Fixed an issue where added text labels sometimes extended beyond the plot (e.g., over the upper y-axis limit). This is now handled better by increasing plot size or adjusting padding/margin.

Made the different geometric layers orderable