### PR TITLE
Fix for Issue #2980 - Add informative error when lag longer than data is specified.

### DIFF
--- a/R/DescriptivesTimeSeries.R
+++ b/R/DescriptivesTimeSeries.R
@@ -97,7 +97,7 @@ DescriptivesTimeSeriesInternal <- function(jaspResults, dataset, options) {
 .tsFillLagPlot <- function(lagPlot, dataset, options) {
   # create lag version of y
   if (options$lagPlotLag >= length(dataset$y)) {
-    .quitAnalysis(gettextf("The specified lag exceeds the number of observations in the data. Please choose a smaller lag.", options$lagPlotLag, length(dataset$y)))
+    .quitAnalysis(gettextf("The specified lag, %1$s, is too large given the %2$s observations in the data. Please choose a smaller lag.", options$lagPlotLag, length(dataset$y)))
   }
   yLag <- c(rep(NA, options$lagPlotLag), dataset$y[1:(length(dataset$y) - options$lagPlotLag)])
 


### PR DESCRIPTION
This is a fix for test error: [TIME SERIES] Descriptives: Lag plot with lag > n #2980

Fixes: https://github.com/jasp-stats/jasp-test-release/issues/2980

I added an informative error for when a lag that exceeds data length is specified by the user.