### PR TITLE
Descriptives now converts ordinal to scale

### DIFF
--- a/inst/qml/Descriptives.qml
+++ b/inst/qml/Descriptives.qml
@@ -46,7 +46,7 @@ Form
 	{
 		infoLabel: qsTr("Input")
 		AvailableVariablesList	{ name: "allVariablesList"								}
-		AssignedVariablesList	{ name: "variables";		title: qsTr("Variables");	info: qsTr("All variables of interest."); allowTypeChange: true }
+		AssignedVariablesList	{ name: "variables";		title: qsTr("Variables");	info: qsTr("All variables of interest."); allowTypeChange: true; allowedColumns: ["scale", "nominal"]}
 		AssignedVariablesList	{ name: "splitBy";			title: qsTr("Split");		info: qsTr("Can be split by a categorical variable such as experimental condition.") ; singleVariable: true; allowedColumns: ["nominal"];	id: splitBy; minLevels: 2; maxLevels: 256 } // without maxLevels entering a continuous variable can freeze/ crash jasp, so we need an arbitrary maximum
 	}
 


### PR DESCRIPTION
As proposed [here](https://github.com/jasp-stats/INTERNAL-jasp/issues/2978#issuecomment-3340169559).

<img width="1159" height="504" alt="image" src="https://github.com/user-attachments/assets/8bea86ae-7025-43f6-a2ac-c82c54bb82e9" />


Benefits over current approach:
- users expect means for ordinal variables
Benefit over old approach:
- Make treatment of ordinal as scale more salient to user (could even add footnote)