### PR TITLE
medians for ordinals, no conversion for quantiles

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -12,7 +12,7 @@ jobs:
 
   unit-tests:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    uses: jasp-stats/jasp-actions/.github/workflows/unittests.yml@v1
+    uses: jasp-stats/jasp-actions/.github/workflows/unittests.yml@master
     with:
       needs_JAGS: false
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jaspDescriptives
 Type: Package
 Title: Descriptives Module for JASP
-Version: 0.96.1
+Version: 0.96.2
 Date: 2026-04-07
 Author: JASP Team
 Website: jasp-stats.org

--- a/R/descriptives.R
+++ b/R/descriptives.R
@@ -437,7 +437,7 @@ DescriptivesInternal <- function(jaspResults, dataset, options) {
   if (options$valid)                          stats$addColumnInfo(name="Valid",                       title=gettext("Valid"),                   type="integer")
   if (options$missing)                        stats$addColumnInfo(name="Missing",                     title=gettext("Missing"),                 type="integer")
   if (options$mode)                           stats$addColumnInfo(name="Mode",                        title=gettext("Mode"),                    type="mixed")
-  if (options$median)                         stats$addColumnInfo(name="Median",                      title=gettext("Median"),                  type="number")
+  if (options$median)                         stats$addColumnInfo(name="Median",                      title=gettext("Median"),                  type="mixed")
   if (options$meanArithmetic)                 stats$addColumnInfo(name="MeanArithmetic",              title=gettext("Mean (arithmetic)"),       type="number")
   if (options$seMean)                         stats$addColumnInfo(name="Std. Error of Mean",          title=gettext("Std. Error of A. Mean"),   type="number")
   if (options$meanCi) {                       stats$addColumnInfo(name="MeanCILB",                    title=meanCiLbTitle,                      type="number", overtitle = meanCiOvertitle)
@@ -605,7 +605,7 @@ DescriptivesInternal <- function(jaspResults, dataset, options) {
   resultsCol[["Missing"]]                 <- if (options$missing) rows - length(na.omitted)
 
   if (columnType == "scale") {
-    resultsCol[["Median"]]                  <- .descriptivesDescriptivesTable_subFunction_OptionChecker(options$median,             na.omitted, median)
+    resultsCol[["Median"]]                  <- if (options$median) toMixedCol(median(na.omitted))
     resultsCol[["MeanArithmetic"]]          <- .descriptivesDescriptivesTable_subFunction_OptionChecker(options$meanArithmetic,     na.omitted, mean)
     resultsCol[["Std. Error of Mean"]]      <- .descriptivesDescriptivesTable_subFunction_OptionChecker(options$seMean,             na.omitted, function(param) { sd(param)/sqrt(length(param))} )
     resultsCol[["MeanGeometric"]]           <- .descriptivesDescriptivesTable_subFunction_OptionChecker(options$meanGeometric,      na.omitted, .geometricMean )
@@ -624,6 +624,14 @@ DescriptivesInternal <- function(jaspResults, dataset, options) {
     resultsCol[["P-value of Shapiro-Wilk"]] <- .descriptivesDescriptivesTable_subFunction_OptionChecker(options$shapiroWilkTest,   na.omitted, function(param) { res <- try(shapiro.test(param)$p.value);   if(isTryError(res)) NaN else res })
     resultsCol[["Sum"]]                     <- .descriptivesDescriptivesTable_subFunction_OptionChecker(options$sum,               na.omitted, sum)
     resultsCol[["Range"]]                   <- .descriptivesDescriptivesTable_subFunction_OptionChecker(options$range,             na.omitted, function(param) { range(param)[2] - range(param)[1]})
+  } else if (columnType == "ordinal") {
+    ordinalType <- .ordinalQuantileType(as.integer(options[["quantilesType"]]))
+    if (options$median) {
+      medianEst <- quantile(na.omitted, 0.5, names = FALSE, type = ordinalType)
+      resultsCol[["Median"]] <- toMixedCol(medianEst)
+    }
+    if (options$iqr)
+      resultsCol[["IQR"]] <- stats::IQR(na.omitted, type = ordinalType)
   }
 
   if (columnType == "scale" || columnType == "ordinal") {
@@ -706,21 +714,11 @@ DescriptivesInternal <- function(jaspResults, dataset, options) {
 
   if (options$quartiles) {
     if (columnType == "scale" || columnType == "ordinal") {
-      # Type 7: default in R
-      # Type 3: Nearest even order statistic (SAS default till ca. 2010).
-      quartileType <- as.integer(options[["quantilesType"]]) # extract number from type for quantile() function
+      quartileType <- as.integer(options[["quantilesType"]])
+      if (columnType == "ordinal")
+        quartileType <- .ordinalQuantileType(quartileType)
 
-      # Treat variable (i.e., na.omitted) as numeric to make all quantile types applicable.
-      # If we would treat ordinals as ordered factors, the quantile function would lead
-      # to an error.
-      # This is necessary because the user can specify the type from the JASP GUI now,
-      # and the type is applied across all input variables.
-      q123 <- quantile(as.numeric(na.omitted), c(.25, .5, .75), names = FALSE, type = quartileType)
-
-      # To get the labels of the ordinal as output in the table and
-      # not the numbers, index the levels of the factor
-      if(columnType == "ordinal")
-        q123 <- levels(na.omitted)[q123]
+      q123 <- quantile(na.omitted, c(.25, .5, .75), names = FALSE, type = quartileType)
 
       resultsCol[["q1"]] <- toMixedCol(q123[1])
       resultsCol[["q2"]] <- toMixedCol(q123[2])
@@ -757,25 +755,14 @@ DescriptivesInternal <- function(jaspResults, dataset, options) {
   }
 
   if (columnType == "scale" || columnType == "ordinal") {
-    # Type 7: default in R
-    # Type 3: Nearest even order statistic (SAS default till ca. 2010).
-    quartileType <- as.integer(options[["quantilesType"]]) # extract number from type for quantile() function
+    quartileType <- as.integer(options[["quantilesType"]])
+    if (columnType == "ordinal")
+      quartileType <- .ordinalQuantileType(quartileType)
 
     if (options$quantilesForEqualGroups) {
 
       for (i in seq(equalGroupsNo - 1)) {
-        # Treat variable (i.e., na.omitted) as numeric to make all quantile types applicable.
-        # If we would treat ordinals as ordered factors, the quantile function would lead
-        # to an error.
-        # This is necessary because the user can specify the type from the JASP GUI now,
-        # and the type is applied across all input variables.
-        quantileEst <- quantile(as.numeric(na.omitted), c(i / equalGroupsNo), names = FALSE, type = quartileType)
-
-        # To get the labels of the ordinal as output in the table and
-        # not the numbers, index the levels of the factor
-        if (columnType == "ordinal")
-          quantileEst <- levels(na.omitted)[quantileEst]
-
+        quantileEst <- quantile(na.omitted, c(i / equalGroupsNo), names = FALSE, type = quartileType)
         resultsCol[[paste0("eg", i)]] <- toMixedCol(quantileEst)
       }
     }
@@ -783,12 +770,7 @@ DescriptivesInternal <- function(jaspResults, dataset, options) {
     if (options$percentiles) {
 
       for (i in percentilesPercentiles) {
-        # See explanation above
-        percentileEst <- quantile(as.numeric(na.omitted), c(i / 100), names = FALSE, type = quartileType)
-
-        if (columnType == "ordinal")
-          percentileEst <- levels(na.omitted)[percentileEst]
-
+        percentileEst <- quantile(na.omitted, c(i / 100), names = FALSE, type = quartileType)
         resultsCol[[paste0("pc", i)]] <- toMixedCol(percentileEst)
       }
     }
@@ -1609,6 +1591,12 @@ DescriptivesInternal <- function(jaspResults, dataset, options) {
   kurtosis <- a * b + c
 
   return(kurtosis)
+}
+
+# R's quantile() on ordered factors only supports types 1 and 3.
+# Fall back to type 3 when the user-selected type is incompatible.
+.ordinalQuantileType <- function(type) {
+  if (type %in% c(1L, 3L)) type else 3L
 }
 
 .descriptivesIqr <- function(x, options) {

--- a/R/descriptives.R
+++ b/R/descriptives.R
@@ -605,7 +605,7 @@ DescriptivesInternal <- function(jaspResults, dataset, options) {
   resultsCol[["Missing"]]                 <- if (options$missing) rows - length(na.omitted)
 
   if (columnType == "scale") {
-    resultsCol[["Median"]]                  <- if (options$median) toMixedCol(median(na.omitted))
+    resultsCol[["Median"]]                  <- .descriptivesDescriptivesTable_subFunction_OptionChecker(options$median,              na.omitted, .descriptivesMedian, options, toMixedCol)
     resultsCol[["MeanArithmetic"]]          <- .descriptivesDescriptivesTable_subFunction_OptionChecker(options$meanArithmetic,     na.omitted, mean)
     resultsCol[["Std. Error of Mean"]]      <- .descriptivesDescriptivesTable_subFunction_OptionChecker(options$seMean,             na.omitted, function(param) { sd(param)/sqrt(length(param))} )
     resultsCol[["MeanGeometric"]]           <- .descriptivesDescriptivesTable_subFunction_OptionChecker(options$meanGeometric,      na.omitted, .geometricMean )
@@ -1597,6 +1597,11 @@ DescriptivesInternal <- function(jaspResults, dataset, options) {
 # Fall back to type 3 when the user-selected type is incompatible.
 .ordinalQuantileType <- function(type) {
   if (type %in% c(1L, 3L)) type else 3L
+}
+
+.descriptivesMedian <- function(x, options, toMixedCol) {
+  type <- as.integer(options[["quantilesType"]])
+  return(toMixedCol(quantile(x, 0.5, names = FALSE, type = type)))
 }
 
 .descriptivesIqr <- function(x, options) {

--- a/R/descriptives.R
+++ b/R/descriptives.R
@@ -495,6 +495,7 @@ DescriptivesInternal <- function(jaspResults, dataset, options) {
   # lets just add footnotes once instead of a gazillion times..
   shouldAddNominalTextFootnote <- FALSE
   shouldAddModeMoreThanOnceFootnote <- FALSE
+  shouldAddOrdinalQuantileTypeFootnote <- FALSE
 
   # Find the number of levels to loop over
   if (wantsSplit) {
@@ -542,6 +543,11 @@ DescriptivesInternal <- function(jaspResults, dataset, options) {
                             colNames = c("MeanGeometric", "MeanHarmonic"),
                             rowNames = paste0(variable, l))
 
+        if (!shouldAddOrdinalQuantileTypeFootnote && subReturn$shouldAddOrdinalQuantileTypeFootnote) {
+          shouldAddOrdinalQuantileTypeFootnote <- TRUE
+          stats$addFootnote(message = gettext("For ordinal variables, quantile type 3 was used because the selected type is not supported."))
+        }
+
       }
     }
   } else { # we dont want to split
@@ -578,6 +584,11 @@ DescriptivesInternal <- function(jaspResults, dataset, options) {
         stats$addFootnote(message = gettext("Geometric and harmonic means are defined only for strictly positive variables, but the data contain some non-positive values."),
                           colNames = c("MeanGeometric", "MeanHarmonic"),
                           rowNames = variable)
+
+      if (!shouldAddOrdinalQuantileTypeFootnote && subReturn$shouldAddOrdinalQuantileTypeFootnote) {
+        shouldAddOrdinalQuantileTypeFootnote <- TRUE
+        stats$addFootnote(message = gettext("For ordinal variables, quantile type 3 was used because the selected type is not supported."))
+      }
 
     }
   }
@@ -675,6 +686,10 @@ DescriptivesInternal <- function(jaspResults, dataset, options) {
   shouldAddExplainEmptySet <- (options$minimum || options$maximum) && valid == 0
 
   shouldAddGeomHarmMeansPositiveFootnote <- columnType == "scale" && (options[["meanGeometric"]] || options[["meanHarmonic"]]) && any(na.omitted <= 0)
+
+  shouldAddOrdinalQuantileTypeFootnote <- columnType == "ordinal" &&
+    !(as.integer(options[["quantilesType"]]) %in% c(1L, 3L)) &&
+    (options$median || options$iqr || options$quartiles || options$quantilesForEqualGroups || options$percentiles)
 
   if (options$mode) {
 
@@ -796,7 +811,8 @@ DescriptivesInternal <- function(jaspResults, dataset, options) {
     shouldAddModeMoreThanOnceFootnote = shouldAddModeMoreThanOnceFootnote,
     shouldAddIdenticalFootnote = shouldAddIdenticalFootnote,
     shouldAddExplainEmptySet = shouldAddExplainEmptySet,
-    shouldAddGeomHarmMeansPositiveFootnote = shouldAddGeomHarmMeansPositiveFootnote
+    shouldAddGeomHarmMeansPositiveFootnote = shouldAddGeomHarmMeansPositiveFootnote,
+    shouldAddOrdinalQuantileTypeFootnote = shouldAddOrdinalQuantileTypeFootnote
   ))
 }
 

--- a/inst/qml/Descriptives.qml
+++ b/inst/qml/Descriptives.qml
@@ -83,7 +83,7 @@ Form
 				label: qsTr("Type")
 				id: quantilesType	
 				indexDefaultValue: 6 // Type 7, the default in R 
-				info: qsTr("Method used to compute quantiles (see Hyndman & Fan, 1996; Langford, 2006, for more information). The selection carries over to the inter-quartile range (IQR), box- and QQ-plot calculations. Note that ordinal variables are treated as continuous for the computations.\n")
+				info: qsTr("Method used to compute quantiles (see Hyndman & Fan, 1996; Langford, 2006, for more information). The selection carries over to the inter-quartile range (IQR) and box-plot calculations.  For ordinal variables, only types 1 and 3 are supported; other types fall back to type 3.\n")
 				values: [
 						{label: qsTr("1"),	                value: 1},
 						{label: qsTr("2 (SAS)"),	        value: 2},
@@ -91,7 +91,7 @@ Form
 						{label: qsTr("4"),	                value: 4},
 						{label: qsTr("5"),	                value: 5},
 						{label: qsTr("6 (Minitab, SPSS)"),	value: 6},
-						{label: qsTr("7 (R)"),	        value: 7},
+						{label: qsTr("7 (R)"),	            value: 7},
 						{label: qsTr("8"),	                value: 8},
 						{label: qsTr("9"),	                value: 9}
 					]


### PR DESCRIPTION
Medians for ordinals, in the same way we provide quantiles/IQR. 
Different approach for the quantile types, which omits the 'as.numeric()' so the R-functions are using the columns as provided (for ordinals the type now defaults to 3 if any other than 1 or 3 is selected, and a footnote placed if this is the case).
Median now also uses the quantile type. 

Fix https://github.com/jasp-stats/jasp-issues/issues/3738