### PR TITLE
Fix Pareto count variable visibility binding

### DIFF
--- a/inst/qml/Descriptives.qml
+++ b/inst/qml/Descriptives.qml
@@ -413,7 +413,6 @@ Form
 
 				DropDown
 				{
-					visible: paretoAddCountVariable.checked
 					name: "paretoAddCountVariable"
 					label: qsTr("Add count variable")
 					showVariableTypeIcon: true


### PR DESCRIPTION
﻿## Summary
- remove the self-referential visibility binding from the Pareto count-variable dropdown

## Why
The control was hidden based on its own checked state. That makes the QML state impossible to drive correctly from saved options and blocked real Descriptives replay from being used as always-on bridge coverage for the `jaspTools`/`jaspSyntax` transition.

## Related PRs
- jaspTools: https://github.com/jasp-stats/jaspTools/pull/79 uses real Descriptives replay as the high-value integration path for local analysis replay.
- jaspSyntax: https://github.com/jasp-stats/jaspSyntax/pull/7 provides the native `.jasp`/QML option preparation that exercises this QML state.
- jaspBase: https://github.com/jasp-stats/jaspBase/pull/204 supplies source-module wrapped analysis replay support.
- jasp-desktop: https://github.com/jasp-stats/jasp-desktop/pull/6221 exposes the native SyntaxInterface APIs used by the bridge stack.

## Verification
- Real Descriptives replay passed through the bridge using `JASP_DESCRIPTIVES_MODULE=C:/JASP-Packages/jaspDescriptives`.
- `git diff --check HEAD~1..HEAD`
